### PR TITLE
chore: remove unused toolbar and debug code

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -17,7 +17,6 @@ window.mumbleWebConfig = {
   settings: {
     voiceMode: "cont", // one of 'cont' (Continuous), 'ptt' (Push-to-Talk)
     pttKey: "ctrl + shift",
-    toolbarVertical: false,
     userCountInChannelName: false,
     audioBitrate: 40000, // bits per second
     samplesPerPacket: 960,

--- a/app/index.js
+++ b/app/index.js
@@ -244,7 +244,6 @@ class Settings {
     const load = (key) => window.localStorage.getItem("mumble." + key);
     this.voiceMode = load("voiceMode") || defaults.voiceMode;
     this.pttKey = load("pttKey") || defaults.pttKey;
-    this.toolbarVertical = load("toolbarVertical") || defaults.toolbarVertical;
     this.userCountInChannelName = ko.observable(
       load("userCountInChannelName") || defaults.userCountInChannelName
     );
@@ -258,7 +257,6 @@ class Settings {
       window.localStorage.setItem("mumble." + key, val);
     save("voiceMode", this.voiceMode);
     save("pttKey", this.pttKey);
-    save("toolbarVertical", this.toolbarVertical);
     save("userCountInChannelName", this.userCountInChannelName());
     save("audioBitrate", this.audioBitrate);
     save("samplesPerPacket", this.samplesPerPacket);
@@ -295,7 +293,6 @@ class GlobalBindings {
     this.thisUser = ko.observable();
     this.root = ko.observable();
     this.messageBox = ko.observable("");
-    this.toolbarHorizontal = ko.observable(!this.settings.toolbarVertical);
     this.selected = ko.observable();
     this.selfMute = ko.observable();
     this.selfDeaf = ko.observable();

--- a/app/voice.js
+++ b/app/voice.js
@@ -97,8 +97,6 @@ export class PushToTalkVoiceHandler extends VoiceHandler {
   }
 }
 
-var theUserMedia = null;
-
 const audioInputSelect = document.querySelector("select#audioSource");
 const selectors = [audioInputSelect];
 
@@ -166,8 +164,6 @@ export function initVoice(onData, onUserMediaError) {
     }
 
     try {
-      theUserMedia = userMedia;
-
       // === NEU: AudioWorklet statt microphone-stream ===
       const ac = new (window.AudioContext || window.webkitAudioContext)({
         sampleRate: 48000,

--- a/debug-identity.js
+++ b/debug-identity.js
@@ -1,1 +1,0 @@
-window.DEBUG_IDENTITY = true;


### PR DESCRIPTION
## Summary
- remove the unused toolbar orientation settings from the default config and UI bindings
- drop the leftover AudioWorklet user media cache since the stream is consumed directly
- delete the unused debug identity helper script

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d07d2faa1c832dbb9c97cdad3c99b9