### PR TITLE
Remove unused toolbar setting and debug helper

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -17,7 +17,6 @@ window.mumbleWebConfig = {
   settings: {
     voiceMode: "cont", // one of 'cont' (Continuous), 'ptt' (Push-to-Talk)
     pttKey: "ctrl + shift",
-    toolbarVertical: false,
     userCountInChannelName: false,
     audioBitrate: 40000, // bits per second
     samplesPerPacket: 960,

--- a/app/index.js
+++ b/app/index.js
@@ -244,7 +244,6 @@ class Settings {
     const load = (key) => window.localStorage.getItem("mumble." + key);
     this.voiceMode = load("voiceMode") || defaults.voiceMode;
     this.pttKey = load("pttKey") || defaults.pttKey;
-    this.toolbarVertical = load("toolbarVertical") || defaults.toolbarVertical;
     this.userCountInChannelName = ko.observable(
       load("userCountInChannelName") || defaults.userCountInChannelName
     );
@@ -258,7 +257,6 @@ class Settings {
       window.localStorage.setItem("mumble." + key, val);
     save("voiceMode", this.voiceMode);
     save("pttKey", this.pttKey);
-    save("toolbarVertical", this.toolbarVertical);
     save("userCountInChannelName", this.userCountInChannelName());
     save("audioBitrate", this.audioBitrate);
     save("samplesPerPacket", this.samplesPerPacket);
@@ -295,7 +293,6 @@ class GlobalBindings {
     this.thisUser = ko.observable();
     this.root = ko.observable();
     this.messageBox = ko.observable("");
-    this.toolbarHorizontal = ko.observable(!this.settings.toolbarVertical);
     this.selected = ko.observable();
     this.selfMute = ko.observable();
     this.selfDeaf = ko.observable();

--- a/app/worker-client.js
+++ b/app/worker-client.js
@@ -3,7 +3,6 @@ import Promise from "promise";
 import EventEmitter from "events";
 import { Writable, PassThrough } from "stream";
 import toArrayBuffer from "to-arraybuffer";
-import ByteBuffer from "bytebuffer";
 // Import the compiled worker bundle. Rename to avoid confusing the global Worker constructor.
 // Native Webpack 5 worker syntax (avoids worker-loader wrapper issues)
 // We keep a small factory so tests / future mocking can override if needed.

--- a/debug-identity.js
+++ b/debug-identity.js
@@ -1,1 +1,0 @@
-window.DEBUG_IDENTITY = true;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 // Added Node polyfills + ProvidePlugin/DefinePlugin to fix runtime 'process is not defined'
 // after upgrading dependencies; keeps vendored mumble-client utils working.
 
-var theme = "../themes/MetroMumbleLight";
 var path = require("path");
 
 module.exports = {


### PR DESCRIPTION
## Summary
- remove the unused toolbar orientation preference from the defaults and settings persistence
- delete the unused debug identity helper alongside stale imports/variables

## Testing
- npm run build
- npm test *(fails: docker entrypoint cannot find `websockify` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d07d2faa1c832dbb9c97cdad3c99b9