### PR TITLE
Remove unused debug identity code

### DIFF
--- a/app/worker-client.js
+++ b/app/worker-client.js
@@ -3,7 +3,6 @@ import Promise from "promise";
 import EventEmitter from "events";
 import { Writable, PassThrough } from "stream";
 import toArrayBuffer from "to-arraybuffer";
-import ByteBuffer from "bytebuffer";
 // Import the compiled worker bundle. Rename to avoid confusing the global Worker constructor.
 // Native Webpack 5 worker syntax (avoids worker-loader wrapper issues)
 // We keep a small factory so tests / future mocking can override if needed.

--- a/debug-identity.js
+++ b/debug-identity.js
@@ -1,1 +1,0 @@
-window.DEBUG_IDENTITY = true;


### PR DESCRIPTION
## Summary
- remove the unused ByteBuffer import from the worker client connector
- delete the stale debug-identity bootstrap that no longer affects the build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d07d2faa1c832dbb9c97cdad3c99b9