### PR TITLE
Remove unused voice state tracking and ByteBuffer import

### DIFF
--- a/app/voice.js
+++ b/app/voice.js
@@ -97,8 +97,6 @@ export class PushToTalkVoiceHandler extends VoiceHandler {
   }
 }
 
-var theUserMedia = null;
-
 const audioInputSelect = document.querySelector("select#audioSource");
 const selectors = [audioInputSelect];
 
@@ -166,8 +164,6 @@ export function initVoice(onData, onUserMediaError) {
     }
 
     try {
-      theUserMedia = userMedia;
-
       // === NEU: AudioWorklet statt microphone-stream ===
       const ac = new (window.AudioContext || window.webkitAudioContext)({
         sampleRate: 48000,

--- a/app/worker-client.js
+++ b/app/worker-client.js
@@ -3,7 +3,6 @@ import Promise from "promise";
 import EventEmitter from "events";
 import { Writable, PassThrough } from "stream";
 import toArrayBuffer from "to-arraybuffer";
-import ByteBuffer from "bytebuffer";
 // Import the compiled worker bundle. Rename to avoid confusing the global Worker constructor.
 // Native Webpack 5 worker syntax (avoids worker-loader wrapper issues)
 // We keep a small factory so tests / future mocking can override if needed.


### PR DESCRIPTION
## Summary
- drop the unused `theUserMedia` placeholder in the voice capture helper
- remove the leftover ByteBuffer import from the worker client proxy

## Testing
- `npm test` *(fails: local image lacks the `websockify` binary required by the e2e smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_68d07d2faa1c832dbb9c97cdad3c99b9