### PR TITLE
identity: disable Netlify credit via logo:false; remove ad-hoc CSS/JS

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -901,6 +901,7 @@ function initializeUI() {
     ui.netlifyIdentity.init({
       APIUrl: "https://welcome.flexpair.com/identity-proxy",
       locale: "en",
+      logo: false,
     });
     user = ui.netlifyIdentity.currentUser();
   } catch (e) {


### PR DESCRIPTION
This pull request makes a minor update to the Netlify Identity UI initialization by disabling the logo display in the UI configuration.

* Set the `logo` option to `false` in the `netlifyIdentity.init` call within `app/index.js` to hide the logo in the authentication UI.