### PR TITLE
Audio compatibility handling

### DIFF
--- a/app/audio-context-manager.js
+++ b/app/audio-context-manager.js
@@ -78,10 +78,13 @@ class AudioContextManager {
   async createAudioContext(options = {}) {
     try {
       const config = {
-        sampleRate: options.sampleRate || AUDIO_CONFIG.SAMPLE_RATE,
         latencyHint: options.latencyHint || AUDIO_CONFIG.LATENCY_HINT,
         ...options
       };
+
+      if (config.sampleRate === undefined || config.sampleRate === null) {
+        delete config.sampleRate;
+      }
 
       console.log('Creating AudioContext with config:', config);
 

--- a/app/index.html
+++ b/app/index.html
@@ -232,6 +232,14 @@
         <div class="dialog-header" data-bind="text: title"></div>
         <div class="dialog-body">
           <p data-bind="text: description"></p>
+          <!-- ko if: hints().length -->
+          <div class="sample-rate-hints">
+            <div class="sample-rate-hints__title" data-bind="text: hintsTitle"></div>
+            <ul data-bind="foreach: hints">
+              <li data-bind="text: $data"></li>
+            </ul>
+          </div>
+          <!-- /ko -->
         </div>
         <div class="dialog-footer">
           <input
@@ -487,6 +495,7 @@
         <div class="mic-permission-content">
           <span class="mic-icon">🎤</span>
           <span>Microphone access denied</span>
+          <p class="mic-permission-message" data-bind="visible: micPermissionErrorMessage, text: micPermissionErrorMessage"></p>
           <button data-bind="click: retryMicrophonePermission" class="mic-permission-button">
             Allow Microphone
           </button>

--- a/app/index.html
+++ b/app/index.html
@@ -224,6 +224,31 @@
         </form>
       </div>
       <!-- /ko -->
+      <!-- ko with: sampleRateWarningDialog -->
+      <div
+        class="connect-dialog sample-rate-dialog dialog"
+        data-bind="visible: visible()"
+      >
+        <div class="dialog-header" data-bind="text: title"></div>
+        <div class="dialog-body">
+          <p data-bind="text: description"></p>
+        </div>
+        <div class="dialog-footer">
+          <input
+            class="dialog-close"
+            type="button"
+            data-bind="click: cancel, value: secondaryLabel"
+          />
+          <!-- ko if: isConfirm -->
+          <input
+            class="dialog-submit"
+            type="button"
+            data-bind="click: joinWithoutAudio, value: primaryLabel"
+          />
+          <!-- /ko -->
+        </div>
+      </div>
+      <!-- /ko -->
       <!-- ko with: connectionInfo -->
       <div class="connection-info-dialog dialog" data-bind="visible: visible">
         <div id="connection-info_title" class="dialog-header">
@@ -383,7 +408,8 @@
           class="tb-unmute tb-active"
           alt="Unmute my microphone"
           data-bind="visible: selfMute,
-            click: function () { requestUnmute(thisUser()) }"
+            css: { 'tb-disabled': $root.audioLockActive },
+            click: $root.handleUnmuteClick"
           rel="unmute"
           src="svg/audio-input-microphone-muted.svg"
         />
@@ -399,7 +425,8 @@
           class="tb-undeaf tb-active"
           alt="Turn sound back on"
           data-bind="visible: selfDeaf,
-            click: function () { requestUndeaf(thisUser()) }"
+            css: { 'tb-disabled': $root.audioLockActive },
+            click: $root.handleUndeafClick"
           rel="undeaf"
           src="svg/audio-output-deafened.svg"
         />

--- a/app/index.js
+++ b/app/index.js
@@ -105,6 +105,84 @@ function ConnectErrorDialog(connectDialog) {
   };
 }
 
+function SampleRateWarningDialog(ui) {
+  var self = this;
+  self.visible = ko.observable(false);
+  self.mode = ko.observable("confirm");
+  self.sampleRate = ko.observable(null);
+  self.pendingConnection = null;
+
+  const formatSampleRate = (value) => {
+    if (typeof value === "number" && !Number.isNaN(value) && value > 0) {
+      return Math.round(value);
+    }
+    return translate("audio.sample_rate.warning.unknown_rate");
+  };
+
+  self.title = ko.pureComputed(() => translate("audio.sample_rate.warning.title"));
+  self.isConfirm = ko.pureComputed(() => self.mode() === "confirm");
+  self.description = ko.pureComputed(() => {
+    const key = self.isConfirm()
+      ? "audio.sample_rate.warning.body"
+      : "audio.sample_rate.warning.info";
+    const template = translate(key);
+    return template.replace("%1", formatSampleRate(self.sampleRate()));
+  });
+  self.primaryLabel = ko.pureComputed(() => translate("audio.sample_rate.warning.accept"));
+  self.secondaryLabel = ko.pureComputed(() => {
+    const key = self.isConfirm()
+      ? "audio.sample_rate.warning.cancel"
+      : "audio.sample_rate.warning.close";
+    return translate(key);
+  });
+
+  self.show = (sampleRate, params) => {
+    if (ui.currentOpenModal() !== null) {
+      return;
+    }
+    self.mode("confirm");
+    self.sampleRate(sampleRate || null);
+    self.pendingConnection = params || null;
+    self.visible(true);
+    ui.currentOpenModal('sampleRateWarning');
+  };
+
+  self.showInfo = (sampleRate) => {
+    if (ui.currentOpenModal() !== null) {
+      return;
+    }
+    self.mode("info");
+    self.sampleRate(sampleRate || null);
+    self.pendingConnection = null;
+    self.visible(true);
+    ui.currentOpenModal('sampleRateWarning');
+  };
+
+  self.hide = () => {
+    self.visible(false);
+    if (ui.currentOpenModal() === 'sampleRateWarning') {
+      ui.currentOpenModal(null);
+    }
+    self.pendingConnection = null;
+  };
+
+  self.joinWithoutAudio = () => {
+    const params = self.pendingConnection;
+    const sampleRate = self.sampleRate();
+    self.hide();
+    if (params) {
+      ui._performConnect(params, {
+        audioEnabled: false,
+        sampleRate,
+      });
+    }
+  };
+
+  self.cancel = () => {
+    self.hide();
+  };
+}
+
 class ConnectionInfo {
   constructor(ui) {
     this._ui = ui;
@@ -314,9 +392,64 @@ class GlobalBindings {
     }
     this.connectDialog = new ConnectDialog();
     this.connectErrorDialog = new ConnectErrorDialog(this.connectDialog);
+    this.sampleRateWarningDialog = new SampleRateWarningDialog(this);
     this.guacamoleFrame = new GuacamoleFrame();
     this.connectionInfo = new ConnectionInfo(this);
     this.settingsDialog = ko.observable();
+
+    this.audioLockActive = ko.observable(false);
+    this.audioLockReason = ko.observable(null);
+    this.audioLockDetails = ko.observable(null);
+
+    this._activateAudioLock = (reason, details = {}) => {
+      this.audioLockReason(reason);
+      this.audioLockDetails(details);
+      this.audioLockActive(true);
+      this.selfMute(true);
+      this.selfDeaf(true);
+      if (voiceHandler) {
+        voiceHandler.setMute(true);
+      }
+    };
+
+    this._clearAudioLock = ({ resetStates = false } = {}) => {
+      if (resetStates && this.audioLockActive()) {
+        this.selfMute(false);
+        this.selfDeaf(false);
+      }
+      this.audioLockActive(false);
+      this.audioLockReason(null);
+      this.audioLockDetails(null);
+    };
+
+    this.notifyAudioLock = () => {
+      const details = this.audioLockDetails() || {};
+      const sr =
+        details.sampleRate !== undefined
+          ? details.sampleRate
+          : this.audioContext && this.audioContext.sampleRate;
+      this.sampleRateWarningDialog.showInfo(sr);
+    };
+
+    this.handleUnmuteClick = () => {
+      if (this.audioLockActive()) {
+        this.notifyAudioLock();
+        return;
+      }
+      if (this.thisUser()) {
+        this.requestUnmute(this.thisUser());
+      }
+    };
+
+    this.handleUndeafClick = () => {
+      if (this.audioLockActive()) {
+        this.notifyAudioLock();
+        return;
+      }
+      if (this.thisUser()) {
+        this.requestUndeaf(this.thisUser());
+      }
+    };
     
     // Modal management - track currently open modal to prevent multiple modals
     this.currentOpenModal = ko.observable(null);
@@ -442,159 +575,198 @@ class GlobalBindings {
       tokens = [],
       channelName = ""
     ) => {
-      var user_roles = (this.netlifyIdentity.currentUser().app_metadata.roles) || [];
-      if (Array.isArray(user_roles)) {
-        // Add "watch" and "listen" roles if they are not already present
-        if (!user_roles.includes("watch")) user_roles.push("watch");
-        if (!user_roles.includes("listen")) user_roles.push("listen");
-        this.netlifyIdentity.currentUser().app_metadata.roles = user_roles
-        
-        // Request microphone permission and show overlay only if denied
-        if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
-          navigator.mediaDevices.getUserMedia({ audio: true })
-            .then(stream => {
-              // Hide overlay if it was shown
-              this.micPermissionDenied(false);
-              // Stop the stream immediately as we just needed the permission
-              stream.getTracks().forEach(track => track.stop());
-            })
-            .catch(err => {
-              console.warn('Microphone permission denied, showing retry option:', err);
-              // Show the overlay at bottom-left to allow retry
-              this.micPermissionDenied(true);
-            });
-        }
-        
-        // Ensure AudioContext is ready and has proper sample rate
-        if (!this.audioContext) {
-          await this.initializeAudioContext();
-        }
-        
-        if (this.audioContext && this.audioContext.sampleRate == 48000) {
-          initVoice(
-            (data) => {
-              if (!ui.client) {
-                if (voiceHandler) {
-                  voiceHandler.end();
-                }
-                voiceHandler = null;
-              } else if (voiceHandler) {
-                voiceHandler.write(data);
-              }
-            },
-            (err) => {
-              log(translate("logentry.mic_init_error"), err);
-            }
-          );
-
-          this.resetClient();
-
-          this.remoteHost(host);
-          this.remotePort(port);
-
-          log(translate("logentry.connecting"), host);
-
-          // Ensure AudioContext is ready before connecting
-          try {
-            if (this.audioContext && this.audioContext.state === 'suspended') {
-              await this.audioContext.resume();
-              console.log('AudioContext resumed for connection');
-            } else if (!this.audioContext) {
-              await this.initializeAudioContext();
-            }
-          } catch (error) {
-            console.warn('AudioContext resume failed, continuing anyway:', error);
-          }
-
-          try {
-            const client = await this.connector
-              .connect(`wss://${host}:${port}`, {
-                username: username,
-                password: password,
-                tokens: tokens,
-              });
-                var user_roles = (this.netlifyIdentity.currentUser()?.app_metadata?.roles) || [];
-                let guac_login = false;
-                if (user_roles.includes("admin")) {
-                  guac_login = "admin";
-                } else if (user_roles.includes("edit")) {
-                  guac_login = "editor";
-                } else if (user_roles.includes("watch")) {
-                  guac_login = "watcher";
-                }
-                if (guac_login) {
-                  this.guacamoleFrame.start(
-                    guac_login,
-                    this.connectDialog.password()
-                  );
-                  this.guacamoleFrame.show();
-                } else {
-                  alert("For visual access please ask your administrator.");
-                }
-                log(translate("logentry.connected"));
-
-                this.client = client;
-                // Prepare for connection errors
-                client.on("error", (err) => {
-                  log(translate("logentry.connection_error"), err);
-                  this.resetClient();
-                });
-
-                // Register all channels, recursively
-                if (channelName.indexOf("/") != 0) {
-                  channelName = "/" + channelName;
-                }
-                const registerChannel = (channel, channelPath) => {
-                  this._newChannel(channel);
-                  if (channelPath === channelName) {
-                    client.self.setChannel(channel);
-                  }
-                  channel.children.forEach((ch) =>
-                    registerChannel(ch, channelPath + "/" + ch.name)
-                  );
-                };
-                registerChannel(client.root, "");
-
-                // Register all users
-                client.users.forEach((user) => this._newUser(user));
-
-                // Register future channels
-                client.on("newChannel", (channel) => this._newChannel(channel));
-                // Register future users
-                client.on("newUser", (user) => this._newUser(user));
-
-                // Set own user and root channel
-                this.thisUser(client.self.__ui);
-                this.root(client.root.__ui);
-                // Upate linked channels
-                this._updateLinks();
-
-                // Startup audio input processing
-                this._updateVoiceHandler();
-                // Tell server our mute/deaf state (if necessary)
-                if (this.selfDeaf()) {
-                  this.client.setSelfDeaf(true);
-                } else if (this.selfMute()) {
-                  this.client.setSelfMute(true);
-                }
-          } catch (err) {
-            if (err.$type && err.$type.name === "Reject") {
-              this.connectErrorDialog.type(err.type);
-              this.connectErrorDialog.reason(err.reason);
-              this.connectErrorDialog.show();
-            } else {
-              log(translate("logentry.connection_error"), err);
-            }
-          }
-        } else {
-          alert(
-            "Please set the sample rate of your audio devices to 48 kHz on system level in order to proceed."
-          );
-        }
-      } else {
+      const identity = this.netlifyIdentity.currentUser();
+      if (!identity || !identity.app_metadata) {
         alert(
           "You do not have permission to connect to the server. Please contact the administrator."
         );
+        return;
+      }
+
+      var user_roles = identity.app_metadata.roles || [];
+      if (!Array.isArray(user_roles)) {
+        user_roles = [];
+      }
+
+      // Ensure roles contain defaults
+      if (!user_roles.includes("watch")) user_roles.push("watch");
+      if (!user_roles.includes("listen")) user_roles.push("listen");
+      identity.app_metadata.roles = user_roles;
+
+      // Prepare AudioContext information before prompting for permissions
+      if (!this.audioContext) {
+        await this.initializeAudioContext();
+      }
+      const currentSampleRate = this.audioContext
+        ? this.audioContext.sampleRate
+        : null;
+      const audioCompatible = currentSampleRate === 48000;
+      const connectionParams = {
+        host,
+        port,
+        username,
+        password,
+        tokens,
+        channelName,
+      };
+
+      if (!audioCompatible) {
+        this.sampleRateWarningDialog.show(currentSampleRate, connectionParams);
+        return;
+      }
+
+      // Request microphone permission and show overlay only if denied
+      if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+        navigator.mediaDevices
+          .getUserMedia({ audio: true })
+          .then((stream) => {
+            this.micPermissionDenied(false);
+            stream.getTracks().forEach((track) => track.stop());
+          })
+          .catch((err) => {
+            console.warn(
+              "Microphone permission denied, showing retry option:",
+              err
+            );
+            this.micPermissionDenied(true);
+          });
+      }
+
+      this._clearAudioLock({ resetStates: true });
+      await this._performConnect(connectionParams, { audioEnabled: true });
+    };
+
+    this._performConnect = async (
+      connectionParams,
+      { audioEnabled = true, sampleRate = null } = {}
+    ) => {
+      const {
+        host,
+        port,
+        username,
+        password,
+        tokens = [],
+        channelName: targetChannel = "",
+      } = connectionParams;
+
+      let channelName = targetChannel;
+
+      if (audioEnabled) {
+        initVoice(
+          (data) => {
+            if (!ui.client) {
+              if (voiceHandler) {
+                voiceHandler.end();
+              }
+              voiceHandler = null;
+            } else if (voiceHandler) {
+              voiceHandler.write(data);
+            }
+          },
+          (err) => {
+            log(translate("logentry.mic_init_error"), err);
+          }
+        );
+      } else {
+        this._activateAudioLock("sample-rate", { sampleRate });
+        if (voiceHandler) {
+          voiceHandler.end();
+          voiceHandler = null;
+        }
+      }
+
+      this.resetClient();
+
+      this.remoteHost(host);
+      this.remotePort(port);
+
+      log(translate("logentry.connecting"), host);
+
+      try {
+        if (this.audioContext && this.audioContext.state === "suspended") {
+          await this.audioContext.resume();
+          console.log("AudioContext resumed for connection");
+        } else if (!this.audioContext) {
+          await this.initializeAudioContext();
+        }
+      } catch (error) {
+        console.warn("AudioContext resume failed, continuing anyway:", error);
+      }
+
+      try {
+        const client = await this.connector.connect(`wss://${host}:${port}`, {
+          username: username,
+          password: password,
+          tokens: tokens,
+        });
+        var user_roles =
+          (this.netlifyIdentity.currentUser()?.app_metadata?.roles) || [];
+        let guac_login = false;
+        if (user_roles.includes("admin")) {
+          guac_login = "admin";
+        } else if (user_roles.includes("edit")) {
+          guac_login = "editor";
+        } else if (user_roles.includes("watch")) {
+          guac_login = "watcher";
+        }
+        if (guac_login) {
+          this.guacamoleFrame.start(
+            guac_login,
+            this.connectDialog.password()
+          );
+          this.guacamoleFrame.show();
+        } else {
+          alert("For visual access please ask your administrator.");
+        }
+        log(translate("logentry.connected"));
+
+        this.client = client;
+        client.on("error", (err) => {
+          log(translate("logentry.connection_error"), err);
+          this.resetClient();
+        });
+
+        if (channelName.indexOf("/") != 0) {
+          channelName = "/" + channelName;
+        }
+        const registerChannel = (channel, channelPath) => {
+          this._newChannel(channel);
+          if (channelPath === channelName) {
+            client.self.setChannel(channel);
+          }
+          channel.children.forEach((ch) =>
+            registerChannel(ch, channelPath + "/" + ch.name)
+          );
+        };
+        registerChannel(client.root, "");
+
+        client.users.forEach((user) => this._newUser(user));
+
+        client.on("newChannel", (channel) => this._newChannel(channel));
+        client.on("newUser", (user) => this._newUser(user));
+
+        this.thisUser(client.self.__ui);
+        this.root(client.root.__ui);
+        this._updateLinks();
+
+        this._updateVoiceHandler();
+
+        if (this.audioLockActive()) {
+          this.client.setSelfMute(true);
+          this.client.setSelfDeaf(true);
+        } else if (this.selfDeaf()) {
+          this.client.setSelfDeaf(true);
+        } else if (this.selfMute()) {
+          this.client.setSelfMute(true);
+        }
+      } catch (err) {
+        if (err.$type && err.$type.name === "Reject") {
+          this.connectErrorDialog.type(err.type);
+          this.connectErrorDialog.reason(err.reason);
+          this.connectErrorDialog.show();
+        } else {
+          log(translate("logentry.connection_error"), err);
+        }
       }
     };
 
@@ -781,7 +953,7 @@ class GlobalBindings {
           this.thisUser().talking("off");
         }
       });
-      if (this.selfMute()) {
+      if (this.audioLockActive() || this.selfMute()) {
         voiceHandler.setMute(true);
       }
 
@@ -861,6 +1033,10 @@ class GlobalBindings {
     };
 
     this.requestUnmute = (user) => {
+      if (this.audioLockActive()) {
+        this.notifyAudioLock();
+        return;
+      }
       if (user !== this.thisUser()) return;
       this.selfMute(false);
       this.selfDeaf(false);
@@ -870,6 +1046,10 @@ class GlobalBindings {
     };
 
     this.requestUndeaf = (user) => {
+      if (this.audioLockActive()) {
+        this.notifyAudioLock();
+        return;
+      }
       if (user !== this.thisUser()) return;
       this.selfDeaf(false);
       if (this.connected()) {

--- a/app/index.js
+++ b/app/index.js
@@ -135,6 +135,17 @@ function SampleRateWarningDialog(ui) {
       : "audio.sample_rate.warning.close";
     return translate(key);
   });
+  self.hintsTitle = ko.pureComputed(() => translate("audio.sample_rate.warning.hints_title"));
+  self.hints = ko.pureComputed(() => {
+    const hintKeys = [
+      "audio.sample_rate.warning.hints.item1",
+      "audio.sample_rate.warning.hints.item2",
+      "audio.sample_rate.warning.hints.item3"
+    ];
+    return hintKeys
+      .map((key) => translate(key))
+      .filter((text) => text && !/^\{\{.*\}\}$/.test(text));
+  });
 
   self.show = (sampleRate, params) => {
     if (ui.currentOpenModal() !== null) {
@@ -374,7 +385,11 @@ class GlobalBindings {
     this.client = null;
     
     // Add microphone permission state observable
-    this.micPermissionDenied = ko.observable(false);
+  this.micPermissionDenied = ko.observable(false);
+  this.micPermissionErrorMessage = ko.observable("");
+    this.micPermissionRetryCount = 0;
+    this.maxMicPermissionRetryCount = 3;
+    this.micPermissionRetryDelayMs = 1000;
     
     // Use netlify-identity-widget from global scope (loaded via script tag)
     if (window.netlifyIdentity && typeof window.netlifyIdentity.init === "function") {
@@ -463,22 +478,53 @@ class GlobalBindings {
     this.selfDeaf = ko.observable();
     
     // Add method to retry microphone permission
-    this.retryMicrophonePermission = () => {
-      if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
-        navigator.mediaDevices.getUserMedia({ audio: true })
-          .then(stream => {
-            this.micPermissionDenied(false);
-            stream.getTracks().forEach(track => track.stop());
-            // Reinitialize voice if needed
-            if (this.client && !voiceHandler) {
-              this._updateVoiceHandler();
-            }
-          })
-          .catch(err => {
-            console.error('Microphone permission denied on retry:', err);
-            alert('Microphone access is required for voice communication. Please check your browser settings.');
-          });
+    this._attemptMicrophonePermission = () => {
+      if (!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia)) {
+        return;
       }
+
+      navigator.mediaDevices
+        .getUserMedia({ audio: true })
+        .then((stream) => {
+          this.micPermissionRetryCount = 0;
+          this.micPermissionDenied(false);
+          this.micPermissionErrorMessage("");
+          stream.getTracks().forEach((track) => track.stop());
+          // Reinitialize voice if needed
+          if (this.client && !voiceHandler) {
+            this._updateVoiceHandler();
+          }
+        })
+        .catch((err) => {
+          console.error("Microphone permission denied on retry:", err);
+          this.micPermissionRetryCount += 1;
+          const isPermissionBlocked =
+            err &&
+            (err.name === "NotAllowedError" ||
+              err.name === "SecurityError" ||
+              (typeof err.message === "string" &&
+                err.message.toLowerCase().includes("denied")));
+
+          if (isPermissionBlocked) {
+            this.micPermissionErrorMessage(
+              "Microphone access is blocked by the browser. Please allow it in the address bar or system settings, then try again."
+            );
+          }
+
+          if (this.micPermissionRetryCount >= this.maxMicPermissionRetryCount) {
+            return;
+          }
+          if (isPermissionBlocked) {
+            return;
+          }
+          setTimeout(() => this._attemptMicrophonePermission(), this.micPermissionRetryDelayMs);
+        });
+    };
+
+    this.retryMicrophonePermission = () => {
+      this.micPermissionRetryCount = 0;
+      this.micPermissionErrorMessage("");
+      this._attemptMicrophonePermission();
     };
     
     // Define initializeAudioContext method before using it

--- a/localize/cs.json
+++ b/localize/cs.json
@@ -55,7 +55,13 @@
         "accept": "Join without audio",
         "cancel": "Cancel",
         "close": "Close",
-        "unknown_rate": "unknown"
+        "unknown_rate": "unknown",
+        "hints_title": "How to switch your device to 48 kHz",
+        "hints": {
+          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
+          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
+          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+        }
       }
     }
   }

--- a/localize/cs.json
+++ b/localize/cs.json
@@ -49,18 +49,18 @@
   "audio": {
     "sample_rate": {
       "warning": {
-        "title": "Audio hardware mismatch",
-        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
-        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
-        "accept": "Join without audio",
-        "cancel": "Cancel",
-        "close": "Close",
-        "unknown_rate": "unknown",
-        "hints_title": "How to switch your device to 48 kHz",
+        "title": "Nesoulad zvukového zařízení",
+        "body": "Vzorkovací frekvence vašeho zvukového zařízení (%1 Hz) neodpovídá požadovaným 48000 Hz. Můžete se připojit bez audia, ale mikrofon i reproduktory zůstanou ztlumené.",
+        "info": "Zvuk je vypnutý, protože vzorkovací frekvence vašeho zvukového zařízení (%1 Hz) neodpovídá požadovaným 48000 Hz.",
+        "accept": "Připojit se bez audia",
+        "cancel": "Zrušit",
+        "close": "Zavřít",
+        "unknown_rate": "neznámá",
+        "hints_title": "Jak přepnout zařízení na 48 kHz",
         "hints": {
-          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
-          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
-          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+          "item1": "Windows: Klikněte pravým tlačítkem na ikonu reproduktoru → Nastavení zvuku → Další nastavení zvuku → vyberte své zařízení → Upřesnit → nastavte Výchozí formát na 48 000 Hz.",
+          "item2": "macOS: Otevřete Aplikace › Nástroje › Nastavení zvuku MIDI → vyberte zařízení → nastavte Formát na 48 000 Hz.",
+          "item3": "Linux: Použijte PulseAudio Volume Control (pavucontrol) nebo systémová nastavení zvuku, zvolte profil 48 kHz a znovu se připojte."
         }
       }
     }

--- a/localize/cs.json
+++ b/localize/cs.json
@@ -45,5 +45,18 @@
   "chat": {
     "channel_message_placeholder": "Sem napište zprávu všem...",
     "user_message_placeholder": "Sem napište zprávu uživateli '%1'..."
+  },
+  "audio": {
+    "sample_rate": {
+      "warning": {
+        "title": "Audio hardware mismatch",
+        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
+        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
+        "accept": "Join without audio",
+        "cancel": "Cancel",
+        "close": "Close",
+        "unknown_rate": "unknown"
+      }
+    }
   }
 }

--- a/localize/de.json
+++ b/localize/de.json
@@ -56,7 +56,13 @@
         "accept": "Join without audio",
         "cancel": "Cancel",
         "close": "Close",
-        "unknown_rate": "unknown"
+        "unknown_rate": "unknown",
+        "hints_title": "How to switch your device to 48 kHz",
+        "hints": {
+          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
+          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
+          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+        }
       }
     }
   }

--- a/localize/de.json
+++ b/localize/de.json
@@ -46,5 +46,18 @@
   "chat": {
     "channel_message_placeholder": "Hier eine Nachricht an alle eintippen...",
     "user_message_placeholder": "Hier eine Nachricht an Teilnehmer '%1' eintippen..."
+  },
+  "audio": {
+    "sample_rate": {
+      "warning": {
+        "title": "Audio hardware mismatch",
+        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
+        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
+        "accept": "Join without audio",
+        "cancel": "Cancel",
+        "close": "Close",
+        "unknown_rate": "unknown"
+      }
+    }
   }
 }

--- a/localize/de.json
+++ b/localize/de.json
@@ -50,18 +50,18 @@
   "audio": {
     "sample_rate": {
       "warning": {
-        "title": "Audio hardware mismatch",
-        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
-        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
-        "accept": "Join without audio",
-        "cancel": "Cancel",
-        "close": "Close",
-        "unknown_rate": "unknown",
-        "hints_title": "How to switch your device to 48 kHz",
+        "title": "Audio-Hardware stimmt nicht überein",
+        "body": "Die Abtastrate deines Audiogeräts (%1 Hz) entspricht nicht den erforderlichen 48000 Hz. Du kannst trotzdem ohne Audio beitreten, aber Mikrofon und Lautsprecher bleiben stumm.",
+        "info": "Audio ist deaktiviert, weil die Abtastrate deines Audiogeräts (%1 Hz) nicht den erforderlichen 48000 Hz entspricht.",
+        "accept": "Ohne Audio beitreten",
+        "cancel": "Abbrechen",
+        "close": "Schließen",
+        "unknown_rate": "unbekannt",
+        "hints_title": "So stellst du dein Gerät auf 48 kHz um",
         "hints": {
-          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
-          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
-          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+          "item1": "Windows: Rechtsklick auf das Lautsprechersymbol → Toneinstellungen → Weitere Soundeinstellungen → Gerät auswählen → Erweitert → Standardformat auf 48.000 Hz setzen.",
+          "item2": "macOS: Programme › Dienstprogramme › Audio-MIDI-Setup öffnen → Gerät auswählen → Format auf 48.000 Hz stellen.",
+          "item3": "Linux: PulseAudio-Lautstärkeregelung (pavucontrol) oder Systemeinstellungen öffnen, ein 48-kHz-Profil wählen und anschließend neu verbinden."
         }
       }
     }

--- a/localize/en.json
+++ b/localize/en.json
@@ -60,7 +60,13 @@
         "accept": "Join without audio",
         "cancel": "Cancel",
         "close": "Close",
-        "unknown_rate": "unknown"
+        "unknown_rate": "unknown",
+        "hints_title": "How to switch your device to 48 kHz",
+        "hints": {
+          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
+          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
+          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+        }
       }
     }
   }

--- a/localize/en.json
+++ b/localize/en.json
@@ -50,5 +50,18 @@
     "connected": "Connected to audio server",
     "connection_error": "Connection error",
     "unknown_voice_mode": "Unknown voice mode"
+  },
+  "audio": {
+    "sample_rate": {
+      "warning": {
+        "title": "Audio hardware mismatch",
+        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
+        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
+        "accept": "Join without audio",
+        "cancel": "Cancel",
+        "close": "Close",
+        "unknown_rate": "unknown"
+      }
+    }
   }
 }

--- a/localize/es.json
+++ b/localize/es.json
@@ -55,7 +55,13 @@
         "accept": "Join without audio",
         "cancel": "Cancel",
         "close": "Close",
-        "unknown_rate": "unknown"
+        "unknown_rate": "unknown",
+        "hints_title": "How to switch your device to 48 kHz",
+        "hints": {
+          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
+          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
+          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+        }
       }
     }
   }

--- a/localize/es.json
+++ b/localize/es.json
@@ -45,5 +45,18 @@
   "chat": {
     "channel_message_placeholder": "Escriba un mensaje para todos aquí...",
     "user_message_placeholder": "Escriba aquí el mensaje para el usuario '%1'..."
+  },
+  "audio": {
+    "sample_rate": {
+      "warning": {
+        "title": "Audio hardware mismatch",
+        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
+        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
+        "accept": "Join without audio",
+        "cancel": "Cancel",
+        "close": "Close",
+        "unknown_rate": "unknown"
+      }
+    }
   }
 }

--- a/localize/es.json
+++ b/localize/es.json
@@ -49,18 +49,18 @@
   "audio": {
     "sample_rate": {
       "warning": {
-        "title": "Audio hardware mismatch",
-        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
-        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
-        "accept": "Join without audio",
-        "cancel": "Cancel",
-        "close": "Close",
-        "unknown_rate": "unknown",
-        "hints_title": "How to switch your device to 48 kHz",
+        "title": "Incompatibilidad de hardware de audio",
+        "body": "La frecuencia de muestreo de tu dispositivo de audio (%1 Hz) no coincide con los 48000 Hz requeridos. Puedes unirte sin audio, pero tu micrófono y tus altavoces permanecerán silenciados.",
+        "info": "El audio está deshabilitado porque la frecuencia de muestreo de tu dispositivo de audio (%1 Hz) no coincide con los 48000 Hz requeridos.",
+        "accept": "Unirse sin audio",
+        "cancel": "Cancelar",
+        "close": "Cerrar",
+        "unknown_rate": "desconocido",
+        "hints_title": "Cómo cambiar tu dispositivo a 48 kHz",
         "hints": {
-          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
-          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
-          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+          "item1": "Windows: Haz clic derecho en el icono del altavoz → Configuración de sonido → Más configuraciones de sonido → selecciona tu dispositivo → Avanzado → establece el formato predeterminado en 48.000 Hz.",
+          "item2": "macOS: Abre Aplicaciones › Utilidades › Configuración de Audio MIDI → selecciona tu dispositivo → establece el formato en 48.000 Hz.",
+          "item3": "Linux: Usa PulseAudio Volume Control (pavucontrol) o la configuración de sonido del sistema para elegir un perfil de 48 kHz y vuelve a conectarte."
         }
       }
     }

--- a/localize/fr.json
+++ b/localize/fr.json
@@ -55,7 +55,13 @@
         "accept": "Join without audio",
         "cancel": "Cancel",
         "close": "Close",
-        "unknown_rate": "unknown"
+        "unknown_rate": "unknown",
+        "hints_title": "How to switch your device to 48 kHz",
+        "hints": {
+          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
+          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
+          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+        }
       }
     }
   }

--- a/localize/fr.json
+++ b/localize/fr.json
@@ -49,18 +49,18 @@
   "audio": {
     "sample_rate": {
       "warning": {
-        "title": "Audio hardware mismatch",
-        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
-        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
-        "accept": "Join without audio",
-        "cancel": "Cancel",
-        "close": "Close",
-        "unknown_rate": "unknown",
-        "hints_title": "How to switch your device to 48 kHz",
+        "title": "Incompatibilité du matériel audio",
+        "body": "La fréquence d'échantillonnage de votre périphérique audio (%1 Hz) n'est pas compatible avec les 48 000 Hz requis. Vous pouvez rejoindre sans audio, mais votre microphone et vos haut-parleurs resteront coupés.",
+        "info": "L'audio est désactivé car la fréquence d'échantillonnage de votre périphérique audio (%1 Hz) n'est pas compatible avec les 48 000 Hz requis.",
+        "accept": "Rejoindre sans audio",
+        "cancel": "Annuler",
+        "close": "Fermer",
+        "unknown_rate": "inconnue",
+        "hints_title": "Comment passer votre appareil en 48 kHz",
         "hints": {
-          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
-          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
-          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+          "item1": "Windows : cliquez droit sur l’icône du haut-parleur → Paramètres audio → Autres paramètres audio → sélectionnez votre périphérique → Avancé → définissez le format par défaut sur 48 000 Hz.",
+          "item2": "macOS : ouvrez Applications › Utilitaires › Configuration Audio et MIDI → sélectionnez votre périphérique → définissez le format sur 48 000 Hz.",
+          "item3": "Linux : utilisez PulseAudio Volume Control (pavucontrol) ou les paramètres audio du système pour choisir un profil 48 kHz, puis reconnectez-vous."
         }
       }
     }

--- a/localize/fr.json
+++ b/localize/fr.json
@@ -45,5 +45,18 @@
   "chat": {
     "channel_message_placeholder": "Tapez un message à tout le monde ici...",
     "user_message_placeholder": "Tapez ici le message à l’utilisateur '%1'..."
+  },
+  "audio": {
+    "sample_rate": {
+      "warning": {
+        "title": "Audio hardware mismatch",
+        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
+        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
+        "accept": "Join without audio",
+        "cancel": "Cancel",
+        "close": "Close",
+        "unknown_rate": "unknown"
+      }
+    }
   }
 }

--- a/localize/it.json
+++ b/localize/it.json
@@ -55,7 +55,13 @@
         "accept": "Join without audio",
         "cancel": "Cancel",
         "close": "Close",
-        "unknown_rate": "unknown"
+        "unknown_rate": "unknown",
+        "hints_title": "How to switch your device to 48 kHz",
+        "hints": {
+          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
+          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
+          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+        }
       }
     }
   }

--- a/localize/it.json
+++ b/localize/it.json
@@ -45,5 +45,18 @@
   "chat": {
     "channel_message_placeholder": "Digita il messaggio per tutti qui...",
     "user_message_placeholder": "Digita qui il messaggio per l'utente '%1'..."
+  },
+  "audio": {
+    "sample_rate": {
+      "warning": {
+        "title": "Audio hardware mismatch",
+        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
+        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
+        "accept": "Join without audio",
+        "cancel": "Cancel",
+        "close": "Close",
+        "unknown_rate": "unknown"
+      }
+    }
   }
 }

--- a/localize/it.json
+++ b/localize/it.json
@@ -49,18 +49,18 @@
   "audio": {
     "sample_rate": {
       "warning": {
-        "title": "Audio hardware mismatch",
-        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
-        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
-        "accept": "Join without audio",
-        "cancel": "Cancel",
-        "close": "Close",
-        "unknown_rate": "unknown",
-        "hints_title": "How to switch your device to 48 kHz",
+        "title": "Incompatibilità dell'hardware audio",
+        "body": "La frequenza di campionamento del tuo dispositivo audio (%1 Hz) non corrisponde ai 48000 Hz richiesti. Puoi comunque partecipare senza audio, ma microfono e altoparlanti resteranno disattivati.",
+        "info": "L'audio è disattivato perché la frequenza di campionamento del tuo dispositivo audio (%1 Hz) non corrisponde ai 48000 Hz richiesti.",
+        "accept": "Partecipa senza audio",
+        "cancel": "Annulla",
+        "close": "Chiudi",
+        "unknown_rate": "sconosciuta",
+        "hints_title": "Come impostare il dispositivo su 48 kHz",
         "hints": {
-          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
-          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
-          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+          "item1": "Windows: fai clic destro sull'icona dell'altoparlante → Impostazioni audio → Altre impostazioni audio → seleziona il dispositivo → Avanzate → imposta il formato predefinito su 48.000 Hz.",
+          "item2": "macOS: apri Applicazioni › Utility › Configurazione Audio MIDI → seleziona il dispositivo → imposta Formato su 48.000 Hz.",
+          "item3": "Linux: usa PulseAudio Volume Control (pavucontrol) o le impostazioni audio di sistema per scegliere un profilo a 48 kHz e poi riconnettiti."
         }
       }
     }

--- a/localize/ja.json
+++ b/localize/ja.json
@@ -45,5 +45,18 @@
   "chat": {
     "channel_message_placeholder": "ここに全員へのメッセージを入力...",
     "user_message_placeholder": "ここにユーザー '％1'へのメッセージを入力してください..."
+  },
+  "audio": {
+    "sample_rate": {
+      "warning": {
+        "title": "Audio hardware mismatch",
+        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
+        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
+        "accept": "Join without audio",
+        "cancel": "Cancel",
+        "close": "Close",
+        "unknown_rate": "unknown"
+      }
+    }
   }
 }

--- a/localize/ja.json
+++ b/localize/ja.json
@@ -55,7 +55,13 @@
         "accept": "Join without audio",
         "cancel": "Cancel",
         "close": "Close",
-        "unknown_rate": "unknown"
+        "unknown_rate": "unknown",
+        "hints_title": "How to switch your device to 48 kHz",
+        "hints": {
+          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
+          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
+          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+        }
       }
     }
   }

--- a/localize/ja.json
+++ b/localize/ja.json
@@ -49,18 +49,18 @@
   "audio": {
     "sample_rate": {
       "warning": {
-        "title": "Audio hardware mismatch",
-        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
-        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
-        "accept": "Join without audio",
-        "cancel": "Cancel",
-        "close": "Close",
-        "unknown_rate": "unknown",
-        "hints_title": "How to switch your device to 48 kHz",
+        "title": "オーディオハードウェアの不一致",
+        "body": "お使いのオーディオデバイスのサンプリングレート（%1 Hz）が必要な 48,000 Hz と一致していません。音声なしで参加することはできますが、マイクとスピーカーはミュートのままになります。",
+        "info": "お使いのオーディオデバイスのサンプリングレート（%1 Hz）が必要な 48,000 Hz と一致していないため、音声は無効になっています。",
+        "accept": "音声なしで参加",
+        "cancel": "キャンセル",
+        "close": "閉じる",
+        "unknown_rate": "不明",
+        "hints_title": "デバイスを 48 kHz に切り替える方法",
         "hints": {
-          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
-          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
-          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+          "item1": "Windows：スピーカーアイコンを右クリック → サウンド設定 → その他のサウンド設定 → デバイスを選択 → 詳細 → 既定の形式を 48,000 Hz に設定します。",
+          "item2": "macOS：アプリケーション › ユーティリティ › Audio MIDI 設定を開く → デバイスを選択 → フォーマットを 48,000 Hz に設定します。",
+          "item3": "Linux：PulseAudio Volume Control（pavucontrol）やシステムのサウンド設定で 48 kHz のプロファイルを選択し、再接続してください。"
         }
       }
     }

--- a/localize/nl.json
+++ b/localize/nl.json
@@ -45,5 +45,18 @@
   "chat": {
     "channel_message_placeholder": "Typ hier een bericht voor iedereen...",
     "user_message_placeholder": "Typ hier een bericht aan gebruiker '%1'..."
+  },
+  "audio": {
+    "sample_rate": {
+      "warning": {
+        "title": "Audio hardware mismatch",
+        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
+        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
+        "accept": "Join without audio",
+        "cancel": "Cancel",
+        "close": "Close",
+        "unknown_rate": "unknown"
+      }
+    }
   }
 }

--- a/localize/nl.json
+++ b/localize/nl.json
@@ -49,18 +49,18 @@
   "audio": {
     "sample_rate": {
       "warning": {
-        "title": "Audio hardware mismatch",
-        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
-        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
-        "accept": "Join without audio",
-        "cancel": "Cancel",
-        "close": "Close",
-        "unknown_rate": "unknown",
-        "hints_title": "How to switch your device to 48 kHz",
+        "title": "Audiohardware komt niet overeen",
+        "body": "De samplefrequentie van je audiapparaat (%1 Hz) komt niet overeen met de vereiste 48.000 Hz. Je kunt alsnog zonder audio deelnemen, maar je microfoon en luidsprekers blijven gedempt.",
+        "info": "Audio is uitgeschakeld omdat de samplefrequentie van je audiapparaat (%1 Hz) niet overeenkomt met de vereiste 48.000 Hz.",
+        "accept": "Deelnemen zonder audio",
+        "cancel": "Annuleren",
+        "close": "Sluiten",
+        "unknown_rate": "onbekend",
+        "hints_title": "Je apparaat naar 48 kHz schakelen",
         "hints": {
-          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
-          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
-          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+          "item1": "Windows: klik met de rechtermuisknop op het luidsprekerpictogram → Geluidsinstellingen → Meer geluidsinstellingen → selecteer je apparaat → Geavanceerd → stel Standaardformaat in op 48.000 Hz.",
+          "item2": "macOS: open Programma's › Hulpprogramma's › Audio/MIDI-configuratie → selecteer je apparaat → stel Formaat in op 48.000 Hz.",
+          "item3": "Linux: gebruik PulseAudio Volume Control (pavucontrol) of de systeemgeluidsinstellingen om een 48 kHz-profiel te kiezen en maak opnieuw verbinding."
         }
       }
     }

--- a/localize/nl.json
+++ b/localize/nl.json
@@ -55,7 +55,13 @@
         "accept": "Join without audio",
         "cancel": "Cancel",
         "close": "Close",
-        "unknown_rate": "unknown"
+        "unknown_rate": "unknown",
+        "hints_title": "How to switch your device to 48 kHz",
+        "hints": {
+          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
+          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
+          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+        }
       }
     }
   }

--- a/localize/no.json
+++ b/localize/no.json
@@ -55,7 +55,13 @@
         "accept": "Join without audio",
         "cancel": "Cancel",
         "close": "Close",
-        "unknown_rate": "unknown"
+        "unknown_rate": "unknown",
+        "hints_title": "How to switch your device to 48 kHz",
+        "hints": {
+          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
+          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
+          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+        }
       }
     }
   }

--- a/localize/no.json
+++ b/localize/no.json
@@ -49,18 +49,18 @@
   "audio": {
     "sample_rate": {
       "warning": {
-        "title": "Audio hardware mismatch",
-        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
-        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
-        "accept": "Join without audio",
-        "cancel": "Cancel",
-        "close": "Close",
-        "unknown_rate": "unknown",
-        "hints_title": "How to switch your device to 48 kHz",
+        "title": "Lydmaskinvaren samsvarer ikke",
+        "body": "Sampleraten til lydenheten din (%1 Hz) samsvarer ikke med de nødvendige 48 000 Hz. Du kan fortsatt bli med uten lyd, men mikrofonen og høyttalerne vil forbli dempet.",
+        "info": "Lyd er deaktivert fordi sampleraten til lydenheten din (%1 Hz) ikke samsvarer med de nødvendige 48 000 Hz.",
+        "accept": "Bli med uten lyd",
+        "cancel": "Avbryt",
+        "close": "Lukk",
+        "unknown_rate": "ukjent",
+        "hints_title": "Slik bytter du enheten til 48 kHz",
         "hints": {
-          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
-          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
-          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+          "item1": "Windows: Høyreklikk på høyttalerikonet → Lydinnstillinger → Flere lydinnstillinger → velg enheten → Avansert → sett standardformatet til 48 000 Hz.",
+          "item2": "macOS: Åpne Programmer › Verktøyprogrammer › Audio MIDI-oppsett → velg enheten → sett formatet til 48 000 Hz.",
+          "item3": "Linux: Bruk PulseAudio Volume Control (pavucontrol) eller systemets lydinnstillinger til å velge en 48 kHz-profil, og koble til igjen."
         }
       }
     }

--- a/localize/no.json
+++ b/localize/no.json
@@ -45,5 +45,18 @@
   "chat": {
     "channel_message_placeholder": "Skriv melding til alle her...",
     "user_message_placeholder": "Skriv meldingen til brukeren '%1' her..."
+  },
+  "audio": {
+    "sample_rate": {
+      "warning": {
+        "title": "Audio hardware mismatch",
+        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
+        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
+        "accept": "Join without audio",
+        "cancel": "Cancel",
+        "close": "Close",
+        "unknown_rate": "unknown"
+      }
+    }
   }
 }

--- a/localize/ru.json
+++ b/localize/ru.json
@@ -55,7 +55,13 @@
         "accept": "Join without audio",
         "cancel": "Cancel",
         "close": "Close",
-        "unknown_rate": "unknown"
+        "unknown_rate": "unknown",
+        "hints_title": "How to switch your device to 48 kHz",
+        "hints": {
+          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
+          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
+          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+        }
       }
     }
   }

--- a/localize/ru.json
+++ b/localize/ru.json
@@ -49,18 +49,18 @@
   "audio": {
     "sample_rate": {
       "warning": {
-        "title": "Audio hardware mismatch",
-        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
-        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
-        "accept": "Join without audio",
-        "cancel": "Cancel",
-        "close": "Close",
-        "unknown_rate": "unknown",
-        "hints_title": "How to switch your device to 48 kHz",
+        "title": "Несоответствие аудиооборудования",
+        "body": "Частота дискретизации вашего аудиоустройства (%1 Гц) не совпадает с требуемыми 48 000 Гц. Вы можете присоединиться без звука, но микрофон и динамики останутся отключёнными.",
+        "info": "Звук отключён, потому что частота дискретизации вашего аудиоустройства (%1 Гц) не совпадает с требуемыми 48 000 Гц.",
+        "accept": "Присоединиться без звука",
+        "cancel": "Отмена",
+        "close": "Закрыть",
+        "unknown_rate": "неизвестно",
+        "hints_title": "Как переключить устройство на 48 кГц",
         "hints": {
-          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
-          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
-          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+          "item1": "Windows: нажмите правой кнопкой по значку динамика → Параметры звука → Дополнительные параметры звука → выберите устройство → Дополнительно → установите значение 48 000 Гц.",
+          "item2": "macOS: откройте Приложения › Утилиты › Аудио MIDI настройка → выберите устройство → установите Формат на 48 000 Гц.",
+          "item3": "Linux: используйте PulseAudio Volume Control (pavucontrol) или системные настройки звука, выберите профиль 48 кГц и подключитесь заново."
         }
       }
     }

--- a/localize/ru.json
+++ b/localize/ru.json
@@ -45,5 +45,18 @@
   "chat": {
     "channel_message_placeholder": "Напишите здесь сообщение всем...",
     "user_message_placeholder": "Напишите здесь сообщение пользователю '%1'..."
+  },
+  "audio": {
+    "sample_rate": {
+      "warning": {
+        "title": "Audio hardware mismatch",
+        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
+        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
+        "accept": "Join without audio",
+        "cancel": "Cancel",
+        "close": "Close",
+        "unknown_rate": "unknown"
+      }
+    }
   }
 }

--- a/localize/zh.json
+++ b/localize/zh.json
@@ -49,18 +49,18 @@
   "audio": {
     "sample_rate": {
       "warning": {
-        "title": "Audio hardware mismatch",
-        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
-        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
-        "accept": "Join without audio",
-        "cancel": "Cancel",
-        "close": "Close",
-        "unknown_rate": "unknown",
-        "hints_title": "How to switch your device to 48 kHz",
+        "title": "音频硬件不匹配",
+        "body": "你的音频设备采样率（%1 Hz）与所需的 48,000 Hz 不匹配。你仍然可以在没有音频的情况下加入，但麦克风和扬声器将保持静音。",
+        "info": "由于你的音频设备采样率（%1 Hz）与所需的 48,000 Hz 不匹配，音频已被禁用。",
+        "accept": "以无音频方式加入",
+        "cancel": "取消",
+        "close": "关闭",
+        "unknown_rate": "未知",
+        "hints_title": "如何将设备切换到 48 kHz",
         "hints": {
-          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
-          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
-          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+          "item1": "Windows：右键点击扬声器图标 → 打开声音设置 → 更多声音设置 → 选择你的设备 → 高级 → 将默认格式设置为 48,000 Hz。",
+          "item2": "macOS：打开 应用程序 › 实用工具 › 音频 MIDI 设置 → 选择你的设备 → 将格式设置为 48,000 Hz。",
+          "item3": "Linux：使用 PulseAudio 音量控制（pavucontrol）或系统声音设置，选择 48 kHz 配置后重新连接。"
         }
       }
     }

--- a/localize/zh.json
+++ b/localize/zh.json
@@ -55,7 +55,13 @@
         "accept": "Join without audio",
         "cancel": "Cancel",
         "close": "Close",
-        "unknown_rate": "unknown"
+        "unknown_rate": "unknown",
+        "hints_title": "How to switch your device to 48 kHz",
+        "hints": {
+          "item1": "Windows: Right-click the speaker icon → Sound settings → More sound settings → select your device → Advanced → set Default Format to 48,000 Hz.",
+          "item2": "macOS: Open Applications › Utilities › Audio MIDI Setup → select your device → set Format to 48,000 Hz.",
+          "item3": "Linux: Use PulseAudio Volume Control (pavucontrol) or system audio settings to choose a 48 kHz profile, then reconnect."
+        }
       }
     }
   }

--- a/localize/zh.json
+++ b/localize/zh.json
@@ -45,5 +45,18 @@
   "chat": {
     "channel_message_placeholder": "在这里向所有人输入消息",
     "user_message_placeholder": "在此处向用户'％1'输入消息"
+  },
+  "audio": {
+    "sample_rate": {
+      "warning": {
+        "title": "Audio hardware mismatch",
+        "body": "Your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz. You can still join without audio, but your microphone and speakers will remain muted.",
+        "info": "Audio is disabled because your audio device sample rate (%1 Hz) doesn't match the required 48000 Hz.",
+        "accept": "Join without audio",
+        "cancel": "Cancel",
+        "close": "Close",
+        "unknown_rate": "unknown"
+      }
+    }
   }
 }

--- a/themes/MetroMumbleLight/main.scss
+++ b/themes/MetroMumbleLight/main.scss
@@ -160,6 +160,23 @@ form {
 .connect-dialog .dialog-close {
   opacity: 0;
 }
+.sample-rate-hints {
+  margin-top: 10px;
+
+  &__title {
+    font-weight: 600;
+    margin-bottom: 6px;
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 18px;
+    li {
+      margin-bottom: 4px;
+      line-height: 1.4;
+    }
+  }
+}
 .dialog {
   position: absolute;
   max-height: calc(100% - 20px);
@@ -245,6 +262,11 @@ select {
     }
 
     .mic-permission-button {
+    .mic-permission-message {
+      margin: 4px 0 0;
+      font-size: 13px;
+      max-width: 240px;
+    }
       background-color: #fff;
       border: 1px solid #333;
       border-radius: 4px;

--- a/themes/MetroMumbleLight/main.scss
+++ b/themes/MetroMumbleLight/main.scss
@@ -87,6 +87,15 @@ iframe {
   border-radius: 3px;
   cursor: pointer;
 }
+.toolbar-horizontal img.tb-disabled {
+  filter: grayscale(100%);
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.toolbar-horizontal img.tb-disabled:hover {
+  border: 1px solid transparent;
+  background-color: transparent;
+}
 .toolbar-horizontal img:hover {
   border: 1px solid $toolbar-hover-bg-color;
   background-color: $toolbar-hover-border-color;


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of audio sample rate compatibility, microphone permission errors, and user interface feedback in the web client. The main focus is to ensure users are properly informed and guided when their device's audio configuration is incompatible or when microphone permissions are denied, while also adding a robust "audio lock" mechanism that prevents unmuting or undeafening when audio is unavailable. The changes span UI enhancements, error handling, and the underlying connection logic.

Key changes include:

**Audio Sample Rate Compatibility & Audio Lock Mechanism**
- Added a new `SampleRateWarningDialog` component to inform users when their device's audio sample rate is incompatible (not 48 kHz), and provide hints or options to proceed without audio. The connection process now checks the sample rate before requesting microphone permissions and displays this dialog if needed. [[1]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5R108-R196) [[2]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L445-R700) [[3]](diffhunk://#diff-12f0145db230b5cf853c879cf69ec9ffadbe7d85235f7b5db889ef5a627dae24R227-R259)
- Introduced an "audio lock" observable state (`audioLockActive`, `audioLockReason`, etc.) that disables unmuting/undeafening and forces mute/deaf when audio is unavailable, with supporting UI feedback and methods to activate/clear the lock. [[1]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5R410-R468) [[2]](diffhunk://#diff-12f0145db230b5cf853c879cf69ec9ffadbe7d85235f7b5db889ef5a627dae24L386-R420) [[3]](diffhunk://#diff-12f0145db230b5cf853c879cf69ec9ffadbe7d85235f7b5db889ef5a627dae24L402-R437)
- Updated the connection logic to use the audio lock and dialog, and to allow joining without audio if the user confirms. [[1]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L445-R700) [[2]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5R716-R722) [[3]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L784-R1002) [[4]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5R1082-R1085) [[5]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5R1095-R1098)

**Microphone Permission Handling**
- Improved microphone permission retry logic to provide user-friendly error messages, retry attempts, and clear feedback when access is blocked by the browser. [[1]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5R389-R392) [[2]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L333-R527) [[3]](diffhunk://#diff-12f0145db230b5cf853c879cf69ec9ffadbe7d85235f7b5db889ef5a627dae24R498)
- Enhanced the UI to display specific error messages and allow users to retry microphone permission requests, including handling for browser/system-level blocks.

**Code Quality and UI Improvements**
- Refactored the connection and audio context initialization logic for clarity, cross-browser compatibility, and maintainability, including safer handling of `sampleRate` in `AudioContextManager`.
- Cleaned up and streamlined code for registering channels, users, and handling connection state, removing redundant alerts and improving feedback. [[1]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L445-R700) [[2]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L497-R749) [[3]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L537-L543) [[4]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L558-R803) [[5]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L589-L598)

These changes collectively provide a more robust, user-friendly experience around audio device compatibility and permissions, reducing user confusion and improving error recovery.

**References:**
- [[1]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5R108-R196) [[2]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5R410-R468) [[3]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L445-R700) [[4]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5R716-R722) [[5]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L333-R527) [[6]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5R389-R392) [[7]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5L784-R1002) [[8]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5R1082-R1085) [[9]](diffhunk://#diff-70b6a4ba131b90d3682f0b2ba111ccabb455e5584068bdfc9744f713f79db1a5R1095-R1098) [[10]](diffhunk://#diff-12f0145db230b5cf853c879cf69ec9ffadbe7d85235f7b5db889ef5a627dae24R227-R259) [[11]](diffhunk://#diff-12f0145db230b5cf853c879cf69ec9ffadbe7d85235f7b5db889ef5a627dae24L386-R420) [[12]](diffhunk://#diff-12f0145db230b5cf853c879cf69ec9ffadbe7d85235f7b5db889ef5a627dae24L402-R437) [[13]](diffhunk://#diff-12f0145db230b5cf853c879cf69ec9ffadbe7d85235f7b5db889ef5a627dae24R498) [[14]](diffhunk://#diff-ae4f3e3fbf2f90bccfa6ffedc1a052ba21c0b6a531f8a4410a05db5222737ab7L81-R88)