### PR TITLE
feat(security): route all traffic through nginx reverse proxy

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,19 +5,18 @@
   "workspaceFolder": "/home/node",
   "remoteUser": "node",
   "overrideCommand": true,
-  "postCreateCommand": "bash -lc 'cd /home/node && echo \"🔧 Fixing murmur data permissions...\" && chmod 777 .devcontainer/murmur_data && docker restart murmur 2>/dev/null || true && node -v && npm -v && npm ci && echo \"🎭 Installing Playwright browsers...\" && npx playwright install chromium && echo \"🚀 Initial build...\" && BUILD_MODE=development node build-esbuild.mjs && echo \"⚙️ Configuring gh CLI...\" && gh repo set-default Flexpair/mumbling-mole || true'",
-  // postStartCommand removed - start dev server manually to avoid system overload and allow inspection
-  // To start manually: ./start-dev-server.sh
-  "postStartCommand": "",
+  "postCreateCommand": "bash -lc 'cd /home/node && echo \"🔧 Fixing murmur data permissions...\" && chmod 777 .devcontainer/murmur_data && docker restart murmur 2>/dev/null || true && node -v && npm -v && npm ci && echo \"🎭 Installing Playwright browsers...\" && npx playwright install chromium && echo \"🚀 Initial build...\" && BUILD_MODE=development node build-esbuild.mjs && echo \"⚙️ Configuring gh CLI...\" && gh repo set-default Flexpair/mumbling-mole || true && echo \"🌐 Setting up nginx DNS...\" && (grep -q local.flexpair.app /etc/hosts || echo \"172.18.0.7 local.flexpair.app\" | sudo tee -a /etc/hosts)'",
+  "postStartCommand": "./start-dev-server.sh",
   "portsAttributes": {
-    "8081": {
+    "443": {
       "label": "App",
-      "onAutoForward": "notify",
+      "onAutoForward": "openBrowser",
+      "protocol": "https",
       "visibility": "public"
     }
   },
   "forwardPorts": [
-    8081
+    443
   ],
   "customizations": {
     "vscode": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - ./letsencrypt:/etc/letsencrypt:ro
     ports:
       - "443:443"
+      - "80:80"
     depends_on:
       - guacamole
       - mumble

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -25,8 +25,6 @@ services:
     networks:
       guacamole_net:
         ipv4_address: 172.18.0.4
-    ports:
-      - "8080/tcp"
     restart: always
 
   mumble:
@@ -43,8 +41,6 @@ services:
       guacamole_net:
         ipv4_address: 172.18.0.6
     container_name: mumble_web_container
-    ports:
-      - "8081:8081"
     depends_on:
       - murmur
     environment:
@@ -65,7 +61,6 @@ services:
       - ./letsencrypt:/etc/letsencrypt:ro
     ports:
       - "443:443"
-      - "80:80"
     depends_on:
       - guacamole
       - mumble
@@ -83,9 +78,6 @@ services:
       guacamole_net:
         ipv4_address: 172.18.0.5
     container_name: murmur
-    ports:
-      - "${MURMUR_PORT:-64738}:${MURMUR_PORT:-64738}"
-      - "${MURMUR_PORT:-64738}:${MURMUR_PORT:-64738}/udp"
     volumes:
       - ./murmur_config/murmur.ini:/etc/mumble/config.ini:ro
       - ./murmur_data:/data

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,6 @@ RUN echo "node ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/node \
 RUN mkdir -p /home/node/.npm && chown -R node:node /home/node
 USER node
 
-EXPOSE 8081 8082
 CMD ["bash", "-lc", "while :; do sleep 3600; done"]
 
 
@@ -132,7 +131,5 @@ COPY --chown=node:node --chmod=555 ./docker-entrypoint.sh /home/node/docker-entr
 
 USER node
 WORKDIR /home/node
-
-EXPOSE 8081 8082
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/home/node/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 PORT="${PORT:-${SMOKE_HTTP_PORT:-8081}}"
-HOST="${HOST:-0.0.0.0}"
+# Bind only to internal Docker network IP - nginx proxies from outside
+# Use 0.0.0.0 only if explicitly set (e.g., for local development without nginx)
+HOST="${HOST:-172.18.0.6}"
 WEBROOT="/home/node/dist"
 
 # Sonderfall: alter HTTP-Smoke-Test → nur statische Dateien auf :8081 ausliefern

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -22,25 +22,21 @@ import { config } from 'dotenv';
 // Load test credentials from .env.test
 config({ path: '.env.test' });
 
-// Auto-detect GitHub Codespaces public URL
+// Auto-detect the appropriate base URL for testing
 const getBaseURL = () => {
   if (process.env.PLAYWRIGHT_BASE_URL) {
     return process.env.PLAYWRIGHT_BASE_URL;
   }
   
-  // In CI (GitHub Actions), use HTTPS with Nginx on port 443
-  if (process.env.CI === 'true') {
-    return 'https://localhost';
-  }
-  
-  // In GitHub Codespaces, use the public forwarded URL
+  // In GitHub Codespaces, use nginx reverse proxy (port 443)
   if (process.env.CODESPACES === 'true' && process.env.CODESPACE_NAME) {
     const domain = process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN || 'app.github.dev';
-    return `https://${process.env.CODESPACE_NAME}-8081.${domain}`;
+    return `https://${process.env.CODESPACE_NAME}-443.${domain}`;
   }
   
-  // Fallback to localhost (dev mode, direct mumble container)
-  return 'http://localhost:8081';
+  // Default: Use nginx reverse proxy (tests full stack with TLS)
+  // Works in both dev container and CI
+  return 'https://local.flexpair.app';
 };
 
 export default defineConfig({
@@ -101,7 +97,7 @@ export default defineConfig({
         '--autoplay-policy=no-user-gesture-required', // Allow audio without user gesture
         '--disable-web-security',                 // For cross-origin WebSocket
         '--allow-file-access-from-files',        // For local file access
-        '--host-resolver-rules=MAP local.flexpair.app 127.0.0.1', // DNS override for Netlify Identity
+        '--host-resolver-rules=MAP local.flexpair.app 172.18.0.7', // DNS override for nginx
       ]
     },
     


### PR DESCRIPTION
## Summary
All backend services are now only accessible through the nginx reverse proxy.

## Security Improvements
- **Dev server binding**: Changed from `0.0.0.0` to internal Docker IP (`172.18.0.6`)
- **Port exposure**: Removed external port mappings for mumble (8081), guacamole (8080), and murmur (64738)
- **Single entry point**: Only port 443 (nginx) is exposed to the host

## Traffic Flow
```
Browser → nginx:443 → mumble:8081 (internal only)
                    → guacamole:8080 (internal only)
                    → murmur:64738 (WebSocket tunnel)
```

## Testing
- Playwright tests now run through nginx (port 443) for full-stack testing
- Verified that direct access to backend services is blocked

## Devcontainer
- Auto-forwards only port 443 as public
- Dev server starts automatically on container start