### PR TITLE
fix(docker): create auth-server directory with proper permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,9 +125,13 @@ CMD ["bash", "-lc", "while :; do sleep 3600; done"]
 # =====================================================================
 FROM base-runtime AS prod
 
-# Copy built artifacts and Python auth-server (no Node.js needed!)
+# Copy built artifacts (no Node.js needed!)
 COPY --from=builder --chown=node:node --chmod=555 /home/node/dist /home/node/dist
-COPY --chown=node:node --chmod=444 ./auth-server/server.py /home/node/auth-server/server.py
+
+# Create auth-server directory (needs 755 for directory traversal)
+RUN mkdir -p /home/node/auth-server && chown node:node /home/node/auth-server
+COPY --chown=node:node --chmod=644 ./auth-server/server.py /home/node/auth-server/server.py
+
 COPY --chown=node:node --chmod=555 ./docker-entrypoint.sh /home/node/docker-entrypoint.sh
 
 USER node


### PR DESCRIPTION
## Summary

Fixes an issue where the auth-server directory was not being created properly in the production Docker image, which could cause the Python auth server to fail.

## Changes

- Add explicit `mkdir -p` for the auth-server directory in the prod stage
- Set directory permissions to 755 (required for directory traversal)
- Change `server.py` file permissions from 444 to 644 (Python needs read access)

## Why

When copying a file into a non-existent directory, Docker creates it implicitly with root ownership. By explicitly creating the directory with proper ownership and permissions, we ensure the `node` user can access and execute the Python auth server script correctly.

## Testing

- [ ] Docker build succeeds
- [ ] Auth server starts correctly in production container