### PR TITLE
fix(auth): capture identity token state before init() clears it

### DIFF
--- a/__tests__/regression/recovery-token-blocked-by-signup.test.js
+++ b/__tests__/regression/recovery-token-blocked-by-signup.test.js
@@ -6,8 +6,9 @@
  * modal. However, initializeAuth() then sees user === null and immediately
  * calls auth.open("signup"), which replaces the recovery modal.
  *
- * FIX: hasIdentityTokenInHash() checks for identity tokens in the URL hash
- * and skips auth.open("signup") when present (only if init succeeded).
+ * FIX: hasIdentityTokenInHash() is called BEFORE auth.init() and the result
+ * is captured, because the widget consumes the hash token during init() and
+ * the adapter deletes __savedIdentityHash — checking afterwards is too late.
  */
 
 import { jest } from '@jest/globals';
@@ -63,12 +64,46 @@ describe('Recovery token blocked by signup modal', () => {
         open: jest.fn(),
       };
 
+      // Capture token presence BEFORE init (mirrors production fix)
+      const hadIdentityToken = hasIdentityTokenInHash(hash);
+
       await mockAuth.init({});
       const initSucceeded = true;
       const user = mockAuth.currentUser();
 
       if (user === null) {
-        if (!initSucceeded || !hasIdentityTokenInHash(hash)) {
+        if (!initSucceeded || !hadIdentityToken) {
+          mockAuth.open('signup');
+        }
+      }
+
+      expect(mockAuth.open).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call auth.open("signup") even when hash is cleared after init (race condition)', async () => {
+      // This is the core regression: the widget clears the hash during init(),
+      // so checking hasIdentityTokenInHash() AFTER init() returns false.
+      const hashBeforeInit = '#recovery_token=IKhPWdwOwPi-c5hbx-yxJA';
+      const hashAfterInit = '';  // widget consumed the token and cleared the hash
+
+      const mockAuth = {
+        init: jest.fn().mockResolvedValue(undefined),
+        currentUser: jest.fn().mockReturnValue(null),
+        open: jest.fn(),
+      };
+
+      // Production fix: capture BEFORE init
+      const hadIdentityToken = hasIdentityTokenInHash(hashBeforeInit);
+
+      await mockAuth.init({});
+      const initSucceeded = true;
+      const user = mockAuth.currentUser();
+
+      // After init, the hash is gone — but we use the pre-init snapshot
+      expect(hasIdentityTokenInHash(hashAfterInit)).toBe(false);  // would have caused the bug
+
+      if (user === null) {
+        if (!initSucceeded || !hadIdentityToken) {
           mockAuth.open('signup');
         }
       }
@@ -85,6 +120,8 @@ describe('Recovery token blocked by signup modal', () => {
         open: jest.fn(),
       };
 
+      const hadIdentityToken = hasIdentityTokenInHash(hash);
+
       let initSucceeded = false;
       try {
         await mockAuth.init({});
@@ -95,7 +132,7 @@ describe('Recovery token blocked by signup modal', () => {
       const user = mockAuth.currentUser();
 
       if (user === null) {
-        if (!initSucceeded || !hasIdentityTokenInHash(hash)) {
+        if (!initSucceeded || !hadIdentityToken) {
           mockAuth.open('signup');
         }
       }
@@ -112,12 +149,14 @@ describe('Recovery token blocked by signup modal', () => {
         open: jest.fn(),
       };
 
+      const hadIdentityToken = hasIdentityTokenInHash(hash);
+
       await mockAuth.init({});
       const initSucceeded = true;
       const user = mockAuth.currentUser();
 
       if (user === null) {
-        if (!initSucceeded || !hasIdentityTokenInHash(hash)) {
+        if (!initSucceeded || !hadIdentityToken) {
           mockAuth.open('signup');
         }
       }
@@ -135,12 +174,14 @@ describe('Recovery token blocked by signup modal', () => {
         open: jest.fn(),
       };
 
+      const hadIdentityToken = hasIdentityTokenInHash(hash);
+
       await mockAuth.init({});
       const initSucceeded = true;
       const user = mockAuth.currentUser();
 
       if (user === null) {
-        if (!initSucceeded || !hasIdentityTokenInHash(hash)) {
+        if (!initSucceeded || !hadIdentityToken) {
           mockAuth.open('signup');
         }
       }

--- a/__tests__/regression/recovery-token-blocked-by-signup.test.js
+++ b/__tests__/regression/recovery-token-blocked-by-signup.test.js
@@ -22,6 +22,29 @@ function hasIdentityTokenInHash(hash) {
   return params.has("recovery_token") || params.has("confirmation_token") || params.has("invite_token");
 }
 
+/**
+ * Simulates the initializeAuth() logic from app/index.js.
+ * Captures token presence BEFORE init, just like the production code.
+ */
+async function simulateInitializeAuth(mockAuth, hash) {
+  const hadIdentityToken = hasIdentityTokenInHash(hash);
+
+  let initSucceeded = false;
+  try {
+    await mockAuth.init({});
+    initSucceeded = true;
+  } catch {
+    // init failed
+  }
+  const user = mockAuth.currentUser();
+
+  if (user === null) {
+    if (!initSucceeded || !hadIdentityToken) {
+      mockAuth.open('signup');
+    }
+  }
+}
+
 describe('Recovery token blocked by signup modal', () => {
 
   describe('hasIdentityTokenInHash()', () => {
@@ -56,26 +79,13 @@ describe('Recovery token blocked by signup modal', () => {
 
   describe('initializeAuth behavior with recovery token', () => {
     it('should NOT call auth.open("signup") when recovery_token is present and init succeeded', async () => {
-      const hash = '#recovery_token=PvfCnpSj_7hdroWcFXP4Ag';
-
       const mockAuth = {
         init: jest.fn().mockResolvedValue(undefined),
         currentUser: jest.fn().mockReturnValue(null),
         open: jest.fn(),
       };
 
-      // Capture token presence BEFORE init (mirrors production fix)
-      const hadIdentityToken = hasIdentityTokenInHash(hash);
-
-      await mockAuth.init({});
-      const initSucceeded = true;
-      const user = mockAuth.currentUser();
-
-      if (user === null) {
-        if (!initSucceeded || !hadIdentityToken) {
-          mockAuth.open('signup');
-        }
-      }
+      await simulateInitializeAuth(mockAuth, '#recovery_token=PvfCnpSj_7hdroWcFXP4Ag');
 
       expect(mockAuth.open).not.toHaveBeenCalled();
     });
@@ -84,7 +94,6 @@ describe('Recovery token blocked by signup modal', () => {
       // This is the core regression: the widget clears the hash during init(),
       // so checking hasIdentityTokenInHash() AFTER init() returns false.
       const hashBeforeInit = '#recovery_token=IKhPWdwOwPi-c5hbx-yxJA';
-      const hashAfterInit = '';  // widget consumed the token and cleared the hash
 
       const mockAuth = {
         init: jest.fn().mockResolvedValue(undefined),
@@ -92,99 +101,45 @@ describe('Recovery token blocked by signup modal', () => {
         open: jest.fn(),
       };
 
-      // Production fix: capture BEFORE init
-      const hadIdentityToken = hasIdentityTokenInHash(hashBeforeInit);
-
-      await mockAuth.init({});
-      const initSucceeded = true;
-      const user = mockAuth.currentUser();
+      await simulateInitializeAuth(mockAuth, hashBeforeInit);
 
       // After init, the hash is gone — but we use the pre-init snapshot
-      expect(hasIdentityTokenInHash(hashAfterInit)).toBe(false);  // would have caused the bug
-
-      if (user === null) {
-        if (!initSucceeded || !hadIdentityToken) {
-          mockAuth.open('signup');
-        }
-      }
-
+      expect(hasIdentityTokenInHash('')).toBe(false);  // would have caused the bug
       expect(mockAuth.open).not.toHaveBeenCalled();
     });
 
     it('should call auth.open("signup") when recovery_token is present but init FAILED', async () => {
-      const hash = '#recovery_token=PvfCnpSj_7hdroWcFXP4Ag';
-
       const mockAuth = {
         init: jest.fn().mockRejectedValue(new Error('network error')),
         currentUser: jest.fn().mockReturnValue(null),
         open: jest.fn(),
       };
 
-      const hadIdentityToken = hasIdentityTokenInHash(hash);
-
-      let initSucceeded = false;
-      try {
-        await mockAuth.init({});
-        initSucceeded = true;
-      } catch {
-        // init failed
-      }
-      const user = mockAuth.currentUser();
-
-      if (user === null) {
-        if (!initSucceeded || !hadIdentityToken) {
-          mockAuth.open('signup');
-        }
-      }
+      await simulateInitializeAuth(mockAuth, '#recovery_token=PvfCnpSj_7hdroWcFXP4Ag');
 
       expect(mockAuth.open).toHaveBeenCalledWith('signup');
     });
 
     it('should call auth.open("signup") when NO token is present', async () => {
-      const hash = '';
-
       const mockAuth = {
         init: jest.fn().mockResolvedValue(undefined),
         currentUser: jest.fn().mockReturnValue(null),
         open: jest.fn(),
       };
 
-      const hadIdentityToken = hasIdentityTokenInHash(hash);
-
-      await mockAuth.init({});
-      const initSucceeded = true;
-      const user = mockAuth.currentUser();
-
-      if (user === null) {
-        if (!initSucceeded || !hadIdentityToken) {
-          mockAuth.open('signup');
-        }
-      }
+      await simulateInitializeAuth(mockAuth, '');
 
       expect(mockAuth.open).toHaveBeenCalledWith('signup');
     });
 
     it('should NOT call auth.open when user is already authenticated', async () => {
-      const hash = '';
-
-      const mockUser = { user_metadata: { full_name: 'Test User' } };
       const mockAuth = {
         init: jest.fn().mockResolvedValue(undefined),
-        currentUser: jest.fn().mockReturnValue(mockUser),
+        currentUser: jest.fn().mockReturnValue({ user_metadata: { full_name: 'Test User' } }),
         open: jest.fn(),
       };
 
-      const hadIdentityToken = hasIdentityTokenInHash(hash);
-
-      await mockAuth.init({});
-      const initSucceeded = true;
-      const user = mockAuth.currentUser();
-
-      if (user === null) {
-        if (!initSucceeded || !hadIdentityToken) {
-          mockAuth.open('signup');
-        }
-      }
+      await simulateInitializeAuth(mockAuth, '');
 
       expect(mockAuth.open).not.toHaveBeenCalled();
     });

--- a/app/index.js
+++ b/app/index.js
@@ -187,6 +187,11 @@ async function initializeAuth() {
   let user = null;
   let initSucceeded = false;
 
+  // Capture token presence BEFORE init() — the widget consumes the hash
+  // token and clears location.hash during netlifyIdentity.init(), and the
+  // adapter deletes __savedIdentityHash, so checking afterwards is too late.
+  const hadIdentityToken = hasIdentityTokenInHash();
+
   try {
     await auth.init(globalThis.mumbleWebConfig.auth?.netlify || {
       APIUrl: "https://welcome.flexpair.com/identity-proxy",
@@ -205,7 +210,7 @@ async function initializeAuth() {
     // Skip signup modal only when init succeeded and the widget can handle the
     // token itself.  If init failed, always fall back to signup so the user
     // is never left with an empty screen.
-    if (!initSucceeded || !hasIdentityTokenInHash()) {
+    if (!initSucceeded || !hadIdentityToken) {
       auth.open("signup");
     }
   } else {


### PR DESCRIPTION
## Summary

- Password recovery links (`#recovery_token=...`) were broken — the reset modal was skipped and the signup modal opened instead
- Root cause: `hasIdentityTokenInHash()` was called **after** `auth.init()`, but by that point both `location.hash` (cleared by widget) and `__savedIdentityHash` (deleted by adapter) were empty — so it always returned `false`
- Fix: capture token presence **before** `auth.init()` while `__savedIdentityHash` still exists

## Test plan

- [x] Regression test for race condition added (hash empty after init, but token correctly detected before)
- [x] All existing regression tests updated to match pre-init capture pattern
- [x] Full test suite passes (1758 tests)
- [ ] Manual test: open `https://demo.flexpair.com/#recovery_token=<valid_token>` → password reset modal should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)