### PR TITLE
fix(auth): let identity tokens take priority over existing sessions

### DIFF
--- a/__tests__/regression/recovery-token-blocked-by-signup.test.js
+++ b/__tests__/regression/recovery-token-blocked-by-signup.test.js
@@ -28,7 +28,7 @@ function hasIdentityTokenInHash(hash) {
 
 /**
  * Simulates the initializeAuth() logic from app/index.js.
- * Returns { openedWith, connectVisible } to verify behavior.
+ * Returns { connectVisible } to verify behavior.
  */
 async function simulateInitializeAuth(mockAuth, hash) {
   const hadIdentityToken = hasIdentityTokenInHash(hash);
@@ -41,7 +41,10 @@ async function simulateInitializeAuth(mockAuth, hash) {
   } catch {
     // init failed
   }
-  const user = mockAuth.currentUser();
+  let user = null;
+  if (initSucceeded) {
+    user = mockAuth.currentUser();
+  }
 
   if (initSucceeded && hadIdentityToken) {
     result.connectVisible = false;

--- a/__tests__/regression/recovery-token-blocked-by-signup.test.js
+++ b/__tests__/regression/recovery-token-blocked-by-signup.test.js
@@ -1,14 +1,18 @@
 /**
- * REGRESSION TEST: Password Recovery Token blocked by signup modal
+ * REGRESSION TEST: Password Recovery Token blocked by signup modal / connect dialog
  *
- * BUG: When opening a recovery link (e.g. #recovery_token=XYZ), the Netlify
- * Identity Widget detects the token during init() and shows the password reset
- * modal. However, initializeAuth() then sees user === null and immediately
- * calls auth.open("signup"), which replaces the recovery modal.
+ * BUG #1: When opening a recovery link (e.g. #recovery_token=XYZ), the widget
+ * detects the token during init() and shows the password reset modal.  However
+ * initializeAuth() then sees user === null and calls auth.open("signup"),
+ * which replaces the recovery modal.
  *
- * FIX: hasIdentityTokenInHash() is called BEFORE auth.init() and the result
- * is captured, because the widget consumes the hash token during init() and
- * the adapter deletes __savedIdentityHash — checking afterwards is too late.
+ * BUG #2: When a user already has a session (localStorage) and opens a recovery
+ * link, auth.currentUser() is non-null so the code jumps to the else-branch
+ * and shows the connect dialog — hiding the recovery modal.
+ *
+ * FIX: Identity tokens take priority.  When a token is present and init
+ * succeeded, skip both signup and connect dialog so the widget can handle
+ * the token (password reset, email confirmation, invite acceptance).
  */
 
 import { jest } from '@jest/globals';
@@ -24,10 +28,11 @@ function hasIdentityTokenInHash(hash) {
 
 /**
  * Simulates the initializeAuth() logic from app/index.js.
- * Captures token presence BEFORE init, just like the production code.
+ * Returns { openedWith, connectVisible } to verify behavior.
  */
 async function simulateInitializeAuth(mockAuth, hash) {
   const hadIdentityToken = hasIdentityTokenInHash(hash);
+  const result = { connectVisible: undefined };
 
   let initSucceeded = false;
   try {
@@ -38,11 +43,16 @@ async function simulateInitializeAuth(mockAuth, hash) {
   }
   const user = mockAuth.currentUser();
 
-  if (user === null) {
-    if (!initSucceeded || !hadIdentityToken) {
-      mockAuth.open('signup');
-    }
+  if (initSucceeded && hadIdentityToken) {
+    result.connectVisible = false;
+  } else if (user === null) {
+    result.connectVisible = false;
+    mockAuth.open('signup');
+  } else {
+    result.connectVisible = true;
   }
+
+  return result;
 }
 
 describe('Recovery token blocked by signup modal', () => {
@@ -77,38 +87,34 @@ describe('Recovery token blocked by signup modal', () => {
     });
   });
 
-  describe('initializeAuth behavior with recovery token', () => {
-    it('should NOT call auth.open("signup") when recovery_token is present and init succeeded', async () => {
+  describe('initializeAuth behavior', () => {
+    it('should let widget handle recovery token (no signup, no connect dialog)', async () => {
       const mockAuth = {
         init: jest.fn().mockResolvedValue(undefined),
         currentUser: jest.fn().mockReturnValue(null),
         open: jest.fn(),
       };
 
-      await simulateInitializeAuth(mockAuth, '#recovery_token=PvfCnpSj_7hdroWcFXP4Ag');
+      const result = await simulateInitializeAuth(mockAuth, '#recovery_token=PvfCnpSj_7hdroWcFXP4Ag');
 
       expect(mockAuth.open).not.toHaveBeenCalled();
+      expect(result.connectVisible).toBe(false);
     });
 
-    it('should NOT call auth.open("signup") even when hash is cleared after init (race condition)', async () => {
-      // This is the core regression: the widget clears the hash during init(),
-      // so checking hasIdentityTokenInHash() AFTER init() returns false.
-      const hashBeforeInit = '#recovery_token=IKhPWdwOwPi-c5hbx-yxJA';
-
+    it('should let widget handle recovery token even when user is already logged in', async () => {
       const mockAuth = {
         init: jest.fn().mockResolvedValue(undefined),
-        currentUser: jest.fn().mockReturnValue(null),
+        currentUser: jest.fn().mockReturnValue({ user_metadata: { full_name: 'Test User' } }),
         open: jest.fn(),
       };
 
-      await simulateInitializeAuth(mockAuth, hashBeforeInit);
+      const result = await simulateInitializeAuth(mockAuth, '#recovery_token=IKhPWdwOwPi-c5hbx-yxJA');
 
-      // After init, the hash is gone — but we use the pre-init snapshot
-      expect(hasIdentityTokenInHash('')).toBe(false);  // would have caused the bug
       expect(mockAuth.open).not.toHaveBeenCalled();
+      expect(result.connectVisible).toBe(false);
     });
 
-    it('should call auth.open("signup") when recovery_token is present but init FAILED', async () => {
+    it('should fall back to signup when token is present but init FAILED', async () => {
       const mockAuth = {
         init: jest.fn().mockRejectedValue(new Error('network error')),
         currentUser: jest.fn().mockReturnValue(null),
@@ -120,7 +126,7 @@ describe('Recovery token blocked by signup modal', () => {
       expect(mockAuth.open).toHaveBeenCalledWith('signup');
     });
 
-    it('should call auth.open("signup") when NO token is present', async () => {
+    it('should open signup when no token and no user', async () => {
       const mockAuth = {
         init: jest.fn().mockResolvedValue(undefined),
         currentUser: jest.fn().mockReturnValue(null),
@@ -132,16 +138,17 @@ describe('Recovery token blocked by signup modal', () => {
       expect(mockAuth.open).toHaveBeenCalledWith('signup');
     });
 
-    it('should NOT call auth.open when user is already authenticated', async () => {
+    it('should show connect dialog when no token and user is authenticated', async () => {
       const mockAuth = {
         init: jest.fn().mockResolvedValue(undefined),
         currentUser: jest.fn().mockReturnValue({ user_metadata: { full_name: 'Test User' } }),
         open: jest.fn(),
       };
 
-      await simulateInitializeAuth(mockAuth, '');
+      const result = await simulateInitializeAuth(mockAuth, '');
 
       expect(mockAuth.open).not.toHaveBeenCalled();
+      expect(result.connectVisible).toBe(true);
     });
   });
 });

--- a/app/index.js
+++ b/app/index.js
@@ -208,6 +208,11 @@ async function initializeAuth() {
     // A recovery/confirmation/invite token is present — let the widget handle
     // it (show password-reset modal, etc.).  Don't open signup or the connect
     // dialog; the widget will fire a "login" event when done.
+    // Preserve username so handleAuthClose() knows the user is authenticated.
+    const username = getUsernameFromMetadata(user);
+    if (username) {
+      dialogStore.connectDialog.username = username;
+    }
     dialogStore.connectDialog.visible = false;
   } else if (user === null) {
     // Hide connect dialog when showing authentication modal

--- a/app/index.js
+++ b/app/index.js
@@ -204,15 +204,15 @@ async function initializeAuth() {
     console.warn('[Auth] Initialization failed; continuing without authentication', e);
   }
 
-  if (user === null) {
+  if (initSucceeded && hadIdentityToken) {
+    // A recovery/confirmation/invite token is present — let the widget handle
+    // it (show password-reset modal, etc.).  Don't open signup or the connect
+    // dialog; the widget will fire a "login" event when done.
+    dialogStore.connectDialog.visible = false;
+  } else if (user === null) {
     // Hide connect dialog when showing authentication modal
     dialogStore.connectDialog.visible = false;
-    // Skip signup modal only when init succeeded and the widget can handle the
-    // token itself.  If init failed, always fall back to signup so the user
-    // is never left with an empty screen.
-    if (!initSucceeded || !hadIdentityToken) {
-      auth.open("signup");
-    }
+    auth.open("signup");
   } else {
     const username = getUsernameFromMetadata(user);
     if (username) {


### PR DESCRIPTION
## Summary
- When a user with an existing session opens a recovery link (`#recovery_token=...`), `auth.currentUser()` returned non-null, so the code showed the connect dialog instead of the password-reset modal
- Identity tokens (recovery, confirmation, invite) now take priority: when present and init succeeded, both signup and connect dialog are suppressed so the widget handles the token
- Refactored regression tests to use `simulateInitializeAuth()` helper, eliminating duplicated test logic

## Test plan
- [x] All 1758 tests pass
- [ ] Open `https://demo.flexpair.com/#recovery_token=<token>` while logged in — password-reset modal should appear
- [ ] Open recovery link while logged out — password-reset modal should appear
- [ ] Open page without token while logged in — connect dialog should appear
- [ ] Open page without token while logged out — signup modal should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)