### PR TITLE
fix(auth): clear stale session before processing identity tokens

### DIFF
--- a/__tests__/auth/NetlifyIdentityAdapter.test.js
+++ b/__tests__/auth/NetlifyIdentityAdapter.test.js
@@ -90,6 +90,54 @@ describe('NetlifyIdentityAdapter - init()', () => {
     );
   }, 10000);
 
+  test('clears gotrue.user from localStorage when savedIdentityHash is present', async () => {
+    globalThis.__savedIdentityHash = '#invite_token=abc123';
+    const removeItemSpy = jest.spyOn(Storage.prototype, 'removeItem');
+
+    adapter = new NetlifyIdentityAdapter();
+    await adapter.init();
+
+    expect(removeItemSpy).toHaveBeenCalledWith('gotrue.user');
+    expect(globalThis.__savedIdentityHash).toBeUndefined();
+    removeItemSpy.mockRestore();
+  });
+
+  test('restores location.hash from savedIdentityHash before init', async () => {
+    globalThis.__savedIdentityHash = '#recovery_token=xyz';
+
+    adapter = new NetlifyIdentityAdapter();
+    await adapter.init();
+
+    // The hash should have been set (widget's init() may then clear it,
+    // but we verify the adapter wrote it before calling init).
+    expect(mockNetlifyIdentity.init).toHaveBeenCalled();
+    expect(globalThis.__savedIdentityHash).toBeUndefined();
+  });
+
+  test('does not clear localStorage when no savedIdentityHash is present', async () => {
+    delete globalThis.__savedIdentityHash;
+    const removeItemSpy = jest.spyOn(Storage.prototype, 'removeItem');
+
+    adapter = new NetlifyIdentityAdapter();
+    await adapter.init();
+
+    expect(removeItemSpy).not.toHaveBeenCalled();
+    removeItemSpy.mockRestore();
+  });
+
+  test('does not throw when localStorage access fails', async () => {
+    globalThis.__savedIdentityHash = '#invite_token=abc123';
+    const removeItemSpy = jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new DOMException('Access denied');
+    });
+
+    adapter = new NetlifyIdentityAdapter();
+    // Should not reject
+    await expect(adapter.init()).resolves.toBeUndefined();
+
+    removeItemSpy.mockRestore();
+  });
+
   test('calls netlifyIdentity.init with config', async () => {
     adapter = new NetlifyIdentityAdapter();
     const config = { container: '#widget' };

--- a/__tests__/auth/NetlifyIdentityAdapter.test.js
+++ b/__tests__/auth/NetlifyIdentityAdapter.test.js
@@ -132,8 +132,12 @@ describe('NetlifyIdentityAdapter - init()', () => {
     });
 
     adapter = new NetlifyIdentityAdapter();
-    // Should not reject
+    // Should not reject — the error is logged but swallowed
     await expect(adapter.init()).resolves.toBeUndefined();
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '[Auth] Could not clear stored session:',
+      expect.any(DOMException),
+    );
 
     removeItemSpy.mockRestore();
   });

--- a/app/auth/NetlifyIdentityAdapter.js
+++ b/app/auth/NetlifyIdentityAdapter.js
@@ -81,7 +81,11 @@ class NetlifyIdentityAdapter extends AuthProvider {
       // JWT to the token-verification request.  Without this, invite/recovery
       // links fail in browsers that already have a logged-in session because
       // the server sees the conflicting Bearer token.
-      try { globalThis.localStorage?.removeItem('gotrue.user'); } catch (_) { /* Private browsing */ }
+      try {
+        globalThis.localStorage?.removeItem('gotrue.user');
+      } catch (e) {
+        console.warn('[Auth] Could not clear stored session:', e);
+      }
       globalThis.location.hash = globalThis.__savedIdentityHash;
       delete globalThis.__savedIdentityHash;
     }

--- a/app/auth/NetlifyIdentityAdapter.js
+++ b/app/auth/NetlifyIdentityAdapter.js
@@ -77,6 +77,11 @@ class NetlifyIdentityAdapter extends AuthProvider {
     // index.html (before the widget loaded). This way the widget's own init()
     // finds the token and processes it with the correctly configured API URL.
     if (globalThis.__savedIdentityHash) {
+      // Clear any existing session so the GoTrue client doesn't attach a stale
+      // JWT to the token-verification request.  Without this, invite/recovery
+      // links fail in browsers that already have a logged-in session because
+      // the server sees the conflicting Bearer token.
+      try { globalThis.localStorage?.removeItem("gotrue.user"); } catch (_) { /* Private browsing */ }
       globalThis.location.hash = globalThis.__savedIdentityHash;
       delete globalThis.__savedIdentityHash;
     }

--- a/app/auth/NetlifyIdentityAdapter.js
+++ b/app/auth/NetlifyIdentityAdapter.js
@@ -81,7 +81,7 @@ class NetlifyIdentityAdapter extends AuthProvider {
       // JWT to the token-verification request.  Without this, invite/recovery
       // links fail in browsers that already have a logged-in session because
       // the server sees the conflicting Bearer token.
-      try { globalThis.localStorage?.removeItem("gotrue.user"); } catch (_) { /* Private browsing */ }
+      try { globalThis.localStorage?.removeItem('gotrue.user'); } catch (_) { /* Private browsing */ }
       globalThis.location.hash = globalThis.__savedIdentityHash;
       delete globalThis.__savedIdentityHash;
     }


### PR DESCRIPTION
## Summary
- Invite/recovery/confirmation links fail in non-incognito tabs because the GoTrue client attaches the existing session's JWT to the token-verification request, causing the server to reject it
- Clears `gotrue.user` from `localStorage` before `netlifyIdentity.init()` when an identity token hash is present, so the widget processes the token cleanly
- In incognito there's no stored session, which is why the same links work there

## Test plan
- [ ] Open an invite link (`#invite_token=...`) in a browser where you're already logged in — should show the invite acceptance modal
- [ ] Open a recovery link (`#recovery_token=...`) in a browser with an existing session — should show the password reset modal
- [ ] Open the app normally (no token) in a browser with an existing session — should show the connect dialog as before
- [ ] Open an invite link in incognito — should still work as before
- [ ] Dismiss the invite modal without accepting — user should be redirected to the login modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)