### PR TITLE
fix: add hysteresis to jitter buffer auto-adjustment

### DIFF
--- a/__tests__/stores/userStore-jitter.test.js
+++ b/__tests__/stores/userStore-jitter.test.js
@@ -226,6 +226,73 @@ describe('useUserStore Jitter Buffer Calculation', () => {
     expect(mockSettingsStore.jitterBufferSize).toBe(8);
   });
 
+  test('should not shrink buffer when delta is exactly 1 (hysteresis)', async () => {
+    const { thisUser } = storeToRefs(userStore);
+    thisUser.value = mockUser.__ui;
+    await nextTick();
+
+    // Set current buffer to 9 packets
+    mockSettingsStore.jitterBufferSize = 9;
+
+    // Stats that yield targetPackets = 8 (delta = 1 → should NOT shrink)
+    // Target = 143 + 4 * 0 = 143ms → ceil(143/20) = 8
+    mockClient.dataStats = { mean: 143, variance: 0, n: 10 };
+
+    dataPingCallback();
+
+    // Should stay at 9 (hysteresis prevents single-packet shrink)
+    expect(mockSettingsStore.jitterBufferSize).toBe(9);
+  });
+
+  test('should shrink buffer when delta is greater than 1', async () => {
+    const { thisUser } = storeToRefs(userStore);
+    thisUser.value = mockUser.__ui;
+    await nextTick();
+
+    // Set current buffer to 10 packets
+    mockSettingsStore.jitterBufferSize = 10;
+
+    // Stats that yield targetPackets = 8 (delta = 2 → should shrink)
+    mockClient.dataStats = { mean: 143, variance: 0, n: 10 };
+
+    dataPingCallback();
+
+    expect(mockSettingsStore.jitterBufferSize).toBe(8);
+  });
+
+  test('should always grow buffer immediately (no hysteresis on grow)', async () => {
+    const { thisUser } = storeToRefs(userStore);
+    thisUser.value = mockUser.__ui;
+    await nextTick();
+
+    // Set current buffer to 5 packets
+    mockSettingsStore.jitterBufferSize = 5;
+
+    // Stats that yield targetPackets = 6 (grow by 1 → should update)
+    // Target = 105 + 4 * 0 = 105ms → ceil(105/20) = 6
+    mockClient.dataStats = { mean: 105, variance: 0, n: 10 };
+
+    dataPingCallback();
+
+    expect(mockSettingsStore.jitterBufferSize).toBe(6);
+  });
+
+  test('should recover from NaN jitterBufferSize (corrupted localStorage)', async () => {
+    const { thisUser } = storeToRefs(userStore);
+    thisUser.value = mockUser.__ui;
+    await nextTick();
+
+    // Simulate corrupted localStorage value
+    mockSettingsStore.jitterBufferSize = NaN;
+
+    mockClient.dataStats = { mean: 143, variance: 0, n: 10 };
+
+    dataPingCallback();
+
+    // Should recover to the calculated target
+    expect(mockSettingsStore.jitterBufferSize).toBe(8);
+  });
+
   test('should handle stats.n = 0 correctly (skip calculation)', async () => {
     const { thisUser } = storeToRefs(userStore);
     thisUser.value = mockUser.__ui;

--- a/app/stores/userStore.js
+++ b/app/stores/userStore.js
@@ -51,7 +51,11 @@ export const useUserStore = defineStore('user', () => {
             const targetMs = latency + (factor * deviation);
             const targetPackets = Math.max(minPackets, Math.ceil(targetMs / 20));
             
-            if (settingsStore.jitterBufferSize !== targetPackets) {
+            const current = settingsStore.jitterBufferSize;
+            // Hysteresis: grow immediately (quality), but only shrink if delta > 1
+            // Prevents oscillation when targetPackets sits on a Math.ceil boundary
+            const shouldUpdate = targetPackets > current || (current - targetPackets) > 1;
+            if (shouldUpdate && current !== targetPackets) {
                debugLog('[VOICE]', `Auto-adjusting jitter buffer (${mode}): ${latency.toFixed(1)}ms + ${factor}*${deviation.toFixed(1)}ms = ${targetMs.toFixed(1)}ms -> ${targetPackets} packets`);
                settingsStore.jitterBufferSize = targetPackets;
             }

--- a/app/stores/userStore.js
+++ b/app/stores/userStore.js
@@ -52,10 +52,16 @@ export const useUserStore = defineStore('user', () => {
             const targetPackets = Math.max(minPackets, Math.ceil(targetMs / 20));
             
             const current = settingsStore.jitterBufferSize;
+            // Guard against corrupted localStorage value (NaN propagates as no-update)
+            if (!Number.isFinite(current)) {
+               debugLog('[VOICE]', `Invalid jitter buffer size (${current}), resetting to ${targetPackets}`);
+               settingsStore.jitterBufferSize = targetPackets;
+               return;
+            }
             // Hysteresis: grow immediately (quality), but only shrink if delta > 1
             // Prevents oscillation when targetPackets sits on a Math.ceil boundary
             const shouldUpdate = targetPackets > current || (current - targetPackets) > 1;
-            if (shouldUpdate && current !== targetPackets) {
+            if (shouldUpdate) {
                debugLog('[VOICE]', `Auto-adjusting jitter buffer (${mode}): ${latency.toFixed(1)}ms + ${factor}*${deviation.toFixed(1)}ms = ${targetMs.toFixed(1)}ms -> ${targetPackets} packets`);
                settingsStore.jitterBufferSize = targetPackets;
             }


### PR DESCRIPTION
## Summary
- Fixes audio stutter occurring exactly every 15 seconds
- Root cause: jitter buffer size oscillated between adjacent values on every 3rd ping (3 × 5s = 15s) due to `Math.ceil` sitting on a rounding boundary
- Each resize triggered packet drops in the AudioWorklet (`playback-buffer-processor.js`), causing audible glitches
- Fix: grow buffer immediately (preserves quality), only shrink if delta > 1 packet — prevents single-packet oscillation while still adapting to genuine network changes

## Test plan
- [ ] Connect to Mumble server and listen for 1+ minutes — no more periodic stutter
- [ ] Watch `[VOICE] Auto-adjusting jitter buffer` logs — should no longer flip-flop between adjacent values
- [ ] Verify audio still adapts when network conditions genuinely change (e.g. increase latency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)