### PR TITLE
fix: disable nginx proxy buffering for Murmur WebSocket

### DIFF
--- a/.devcontainer/nginx/conf.d/default.conf
+++ b/.devcontainer/nginx/conf.d/default.conf
@@ -56,6 +56,7 @@ server {
     # Murmur WebSocket
     location /murmur {
         proxy_pass http://mumble:8081;
+        proxy_buffering off;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;


### PR DESCRIPTION
proxy_buffering was left at default (on) for /murmur WebSocket, causing periodic audio stutter. Aligns with /guacamole/ which already had proxy_buffering off.