### PR TITLE
diag: audio buffer diagnostics for 15s stutter

### DIFF
--- a/app/audio/buffer-queue-node.js
+++ b/app/audio/buffer-queue-node.js
@@ -192,6 +192,9 @@ class BufferQueueNode extends EventEmitter {
           this.emit('close');
         } else if (type === 'closed') {
           // Worklet confirmed shutdown
+        } else if (type === 'stats') {
+          // DIAG: Emit stats for external logging
+          this.emit('bufferStats', event.data);
         }
       };
       

--- a/app/audio/playback-buffer-processor.js
+++ b/app/audio/playback-buffer-processor.js
@@ -14,18 +14,21 @@
 registerProcessor('playback-buffer-processor', class extends AudioWorkletProcessor {
   constructor() {
     super();
-    
+
     // FIX #201: Maximum queue size to prevent memory leak
     // 25 packets = 500ms jitter buffer (25 * 20ms frames @ 48kHz)
     // Provides balance between latency and robustness
     this._MAX_QUEUE_SIZE = 25;
-    
+
     this._queue = [];
     this._currentBuffer = null;
     this._currentBufferOffset = 0;
     this._shuttingDown = false;
     this._shutDown = false;
     this._droppedPackets = 0; // Counter for monitoring
+    this._lastDroppedPackets = 0; // For delta reporting
+    this._processCallCount = 0; // For periodic stats reporting
+    this._underrunCount = 0; // Buffer underrun counter
     
     // Listen for incoming audio data from main thread
     this.port.onmessage = (event) => {
@@ -127,12 +130,13 @@ registerProcessor('playback-buffer-processor', class extends AudioWorkletProcess
     
     const frameCount = output[0].length;
     let outputOffset = 0;
-    
+
     while (outputOffset < frameCount) {
       this._getNextBuffer();
-      
+
       if (!this._currentBuffer) {
         this._fillSilence(output, outputOffset);
+        this._underrunCount++;
         this._shouldShutDown();
         break;
       }
@@ -144,7 +148,24 @@ registerProcessor('playback-buffer-processor', class extends AudioWorkletProcess
       this._copyAudioData(output, outputOffset, sampleCount);
       outputOffset += sampleCount;
     }
-    
+
+    // DIAG: Report queue stats every ~1 second (48000/128 ≈ 375 calls/sec)
+    this._processCallCount++;
+    if (this._processCallCount >= 375) {
+      const newDrops = this._droppedPackets - this._lastDroppedPackets;
+      this.port.postMessage({
+        type: 'stats',
+        queueLength: this._queue.length,
+        maxQueueSize: this._MAX_QUEUE_SIZE,
+        droppedPackets: newDrops,
+        totalDropped: this._droppedPackets,
+        underruns: this._underrunCount
+      });
+      this._lastDroppedPackets = this._droppedPackets;
+      this._underrunCount = 0;
+      this._processCallCount = 0;
+    }
+
     return true;
   }
 });

--- a/app/stores/userStore.js
+++ b/app/stores/userStore.js
@@ -62,6 +62,7 @@ export const useUserStore = defineStore('user', () => {
             // Prevents oscillation when targetPackets sits on a Math.ceil boundary
             const shouldUpdate = targetPackets > current || (current - targetPackets) > 1;
             if (shouldUpdate) {
+               console.warn(`[DIAG] JITTER RESIZE: ${current} -> ${targetPackets} packets (latency=${latency.toFixed(1)}ms, dev=${deviation.toFixed(1)}ms) t=${new Date().toISOString().slice(11, 23)}`);
                debugLog('[VOICE]', `Auto-adjusting jitter buffer (${mode}): ${latency.toFixed(1)}ms + ${factor}*${deviation.toFixed(1)}ms = ${targetMs.toFixed(1)}ms -> ${targetPackets} packets`);
                settingsStore.jitterBufferSize = targetPackets;
             }
@@ -95,7 +96,10 @@ export const useUserStore = defineStore('user', () => {
     debugLog('[VOICE]', 'Jitter buffer auto-adjust enabled for user', newUser.name);
     
     // Listen for dataPing to update stats-based calculation
-    client.on('dataPing', recalculateJitterBuffer);
+    client.on('dataPing', (duration) => {
+      console.log(`[DIAG] dataPing RTT=${duration}ms t=${new Date().toISOString().slice(11, 23)}`);
+      recalculateJitterBuffer();
+    });
     
     // Initialize buffer immediately
     recalculateJitterBuffer();
@@ -245,6 +249,18 @@ export const useUserStore = defineStore('user', () => {
       analyzer: frequencyAnalyzer,
       stopWatch: stopDeafWatch,
       userNode: userNode
+    });
+
+    // DIAG: Log buffer stats from AudioWorklet (reports every ~1s)
+    userNode.on('bufferStats', (stats) => {
+      const hasIssue = stats.droppedPackets > 0 || stats.underruns > 0;
+      const log = hasIssue ? console.warn : console.log;
+      log(
+        `[DIAG] queue=${stats.queueLength}/${stats.maxQueueSize}`,
+        hasIssue ? `DROPS=${stats.droppedPackets} UNDERRUNS=${stats.underruns}` : '',
+        `total_drops=${stats.totalDropped}`,
+        `t=${new Date().toISOString().slice(11, 23)}`
+      );
     });
 
     stream


### PR DESCRIPTION
## Summary
- Adds always-on `[DIAG]` console logging to investigate periodic audio stuttering (~15s interval) in production
- AudioWorklet reports queue length, packet drops, and buffer underruns every ~1 second
- dataPing RTT and jitter buffer resize events are logged with timestamps
- Enables correlation of stutter events with buffer state changes

## What to look for in console
```
[DIAG] queue=5/25          total_drops=0  t=12:34:56.789   ← normal
[DIAG] queue=0/25 DROPS=3 UNDERRUNS=12   total_drops=3     ← problem!
[DIAG] JITTER RESIZE: 25 -> 8 packets                      ← suspect
[DIAG] dataPing RTT=42ms                                    ← normal
[DIAG] dataPing RTT=850ms                                   ← spike!
```

## Test plan
- [ ] Deploy to production, play music on desktop
- [ ] Open browser console, observe `[DIAG]` logs for ~2 minutes
- [ ] Correlate yellow `console.warn` entries with audible stutter
- [ ] Identify whether stutter = underruns (buffer empty), drops (buffer overflow), or jitter resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)