### PR TITLE
docs: record session lessons in Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,8 @@ Browser-based Mumble voice client using Vue.js 3, Web Audio API, and WebSocket t
 10. **Playwright locators** – Use role-based (`getByRole`, `getByLabel`) with `.or()` fallbacks.
 11. **Never edit mumble-proto-minimal.js** – Auto-generated; modify `Mumble.proto` or `scripts/generate-proto.sh`.
 12. **Git remote policy** – Never interact with the `upstream` repo/remote. Assume all git operations (push/PR base/merge targets) refer to the Flexpair fork (`origin`, e.g. `Flexpair/mumbling-mole`) unless explicitly instructed otherwise.
+13. **Jest CI dependencies** – Do not omit optional npm dependencies for Jest 30.x CI. Clean Linux CI reproduced resolver failures for local `<rootDir>` config paths when using `npm ci --omit=optional`; prefer the workflow pattern `npm ci || npm i` unless a new clean-container test proves otherwise.
+14. **Dependabot PR search** – Dependabot development-dependency PRs use the title prefix `build(deps-dev)`, not `build(deps/dev)`. Search both variants only when investigating historical mentions.
 
 ## 🎯 Quick Start
 
@@ -100,6 +102,11 @@ npm run test:unit:coverage     # With coverage report
 npm run test:loopback:headed   # Playwright with visible browser
 npm run test:loopback:debug    # Step-through debugging
 ```
+
+### CI Reproduction
+
+- Local `node_modules` can hide dependency-resolution failures. Reproduce CI-only Jest issues in a clean Linux container with a fresh `npm ci` before changing Jest config or custom transformers.
+- If Jest reports that an existing local transformer such as `<rootDir>/jest.text-transformer.cjs` cannot be found, check the install mode first; the file may exist while Jest resolution is broken by omitted optional dependencies.
 
 ### Loopback Test Limitation
 ⚠️ Loopback (`target=31`) tests same-client audio path only. Does NOT validate:


### PR DESCRIPTION
Records the Jest CI and Dependabot lessons from the dependency-update debugging session in the versioned Copilot instructions.