### PR TITLE
Fix Playwright reverse-proxy URL handling

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -22,20 +22,17 @@ import { config } from 'dotenv';
 // Load test credentials from .env.test
 config({ path: '.env.test' });
 
-// Auto-detect the appropriate base URL for testing
+// Prefer the local reverse-proxy URL that the dev container exposes.
+// This avoids the GitHub Codespaces forwarding page, which can redirect to
+// GitHub authentication instead of the app itself.
 const getBaseURL = () => {
   if (process.env.PLAYWRIGHT_BASE_URL) {
     return process.env.PLAYWRIGHT_BASE_URL;
   }
-  
-  // In GitHub Codespaces, use nginx reverse proxy (port 443)
-  if (process.env.CODESPACES === 'true' && process.env.CODESPACE_NAME) {
-    const domain = process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN || 'app.github.dev';
-    return `https://${process.env.CODESPACE_NAME}-443.${domain}`;
-  }
-  
-  // Default: Use nginx reverse proxy (tests full stack with TLS)
-  // Works in both dev container and CI
+
+  // Default: Use the nginx reverse proxy for the full TLS path.
+  // Override with PLAYWRIGHT_BASE_URL when you intentionally want a
+  // different target (for example, a forwarded Codespaces URL).
   return 'https://local.flexpair.app';
 };
 
@@ -118,12 +115,12 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { 
+      use: {
         ...devices['Desktop Chrome'],
         channel: 'chromium', // Use system Chromium if available
-        // Force headed mode in CI for audio tests (fake devices need rendering context)
-        // In Codespace, headless works fine since it has proper audio context
-        headless: !process.env.CI
+        // Default to headless for CI/container environments. Use `--headed` explicitly
+        // when you really want a visible browser on a machine with an X server.
+        headless: process.env.PLAYWRIGHT_HEADLESS !== 'false'
       }
     }
   ],

--- a/tests/playwright/loopback-frequency.spec.js
+++ b/tests/playwright/loopback-frequency.spec.js
@@ -68,18 +68,31 @@ test.describe('Loopback Frequency Test', () => {
     
     await page.goto('/?debug-audio', { waitUntil: 'networkidle', timeout: 30000 });
     
-    // Handle GitHub Codespaces "Continue" button if present
+    // Handle the GitHub Codespaces interstitial only when the current page is
+    // actually on the forwarded Codespaces domain. This avoids false positives
+    // on the real app page.
     console.log('🔍 Checking for GitHub Codespaces interstitial page...');
     try {
-      const continueButton = page.locator('button:has-text("Continue"), a:has-text("Continue")');
-      await expect(continueButton).toBeVisible({ timeout: 2000 });
-      console.log('✅ Found Codespaces Continue button, clicking...');
-      await continueButton.click();
-      await page.waitForLoadState('networkidle', { timeout: 10000 });
-      console.log('✅ Passed Codespaces interstitial');
+      const isCodespacesInterstitial = /(?:app\.github\.dev|github\.dev)/i.test(page.url());
+      if (!isCodespacesInterstitial) {
+        console.log('ℹ️  Not on a Codespaces forwarding URL; skipping interstitial handling');
+      } else {
+        const continueButton = page
+          .getByRole('button', { name: /open in browser/i })
+          .or(page.getByRole('link', { name: /open in browser/i }))
+          .first();
+
+        if (await continueButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+          console.log('✅ Found Codespaces interstitial action, clicking...');
+          await continueButton.click();
+          await page.waitForLoadState('networkidle', { timeout: 10000 });
+          console.log('✅ Passed Codespaces interstitial');
+        } else {
+          console.log('ℹ️  No Codespaces interstitial action button found');
+        }
+      }
     } catch {
-      // Expected when not running in Codespaces environment
-      console.log('ℹ️  No Codespaces interstitial page');
+      console.log('ℹ️  No Codespaces interstitial page detected');
     }
     
     // Handle Netlify Identity login


### PR DESCRIPTION
This pull request improves the reliability and developer experience of Playwright tests by refining environment detection, browser launch configuration, and handling of GitHub Codespaces interstitial pages. The changes ensure tests run smoothly in various environments, especially when using Codespaces or CI.

**Environment and base URL selection:**

* Updated the `getBaseURL` logic in `playwright.config.js` to always prefer the local reverse-proxy URL (`https://local.flexpair.app`) unless explicitly overridden, avoiding issues with GitHub Codespaces forwarding and authentication redirects.

**Browser launch configuration:**

* Changed the default Playwright browser launch mode in `playwright.config.js` to be headless unless `PLAYWRIGHT_HEADLESS` is set to `'false'`, making headless mode the default for CI and container environments and requiring explicit opt-in for headed mode.

**Test robustness in Codespaces:**

* Improved the Codespaces interstitial handling logic in `tests/playwright/loopback-frequency.spec.js` to only attempt to bypass the interstitial page when actually on a Codespaces forwarding domain, reducing false positives and making the test more robust.