### PR TITLE
fix: resolve SonarQube findings (security, a11y, and test-quality)

### DIFF
--- a/__tests__/audio/audio-context-manager.test.js
+++ b/__tests__/audio/audio-context-manager.test.js
@@ -109,7 +109,7 @@ describe('AudioContextManager', () => {
     await audioContextManager.getAudioContext();
     await audioContextManager.closeAudioContext();
     expect(mockAudioContext.close).toHaveBeenCalled();
-    expect(audioContextManager.audioContext).toBe(null);
+    expect(audioContextManager.audioContext).toBeNull();
   });
 
   test('onReady callback fires', async () => {

--- a/__tests__/audio/buffer-queue-node.test.js
+++ b/__tests__/audio/buffer-queue-node.test.js
@@ -60,9 +60,9 @@ describe('Float32ArrayWrapper', () => {
     
     const result = wrapper.toChannelData();
     
-    expect(result.channels.length).toBe(1);
+    expect(result.channels).toHaveLength(1);
     expect(result.channels[0]).toEqual(new Float32Array([0.1, 0.2, 0.3, 0.4]));
-    expect(result.length).toBe(4);
+    expect(result).toHaveLength(4);
   });
 
   test('converts non-interleaved stereo to channel data', () => {
@@ -72,10 +72,10 @@ describe('Float32ArrayWrapper', () => {
     
     const result = wrapper.toChannelData();
     
-    expect(result.channels.length).toBe(2);
+    expect(result.channels).toHaveLength(2);
     expect(result.channels[0]).toEqual(new Float32Array([0.1, 0.2]));
     expect(result.channels[1]).toEqual(new Float32Array([0.3, 0.4]));
-    expect(result.length).toBe(2);
+    expect(result).toHaveLength(2);
   });
 
   test('converts interleaved stereo to channel data', () => {
@@ -85,10 +85,10 @@ describe('Float32ArrayWrapper', () => {
     
     const result = wrapper.toChannelData();
     
-    expect(result.channels.length).toBe(2);
+    expect(result.channels).toHaveLength(2);
     expect(result.channels[0]).toEqual(new Float32Array([0.1, 0.2]));
     expect(result.channels[1]).toEqual(new Float32Array([0.3, 0.4]));
-    expect(result.length).toBe(2);
+    expect(result).toHaveLength(2);
   });
 
   test('handles Buffer input', () => {
@@ -109,7 +109,7 @@ describe('Float32ArrayWrapper', () => {
     const data = new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]);
     const wrapper = new Float32ArrayWrapper(2, false, data);
     
-    expect(wrapper.length).toBe(3); // 6 samples / 2 channels
+    expect(wrapper).toHaveLength(3); // 6 samples / 2 channels
   });
 });
 
@@ -134,8 +134,8 @@ describe('Int16ArrayWrapper', () => {
     
     const result = wrapper.toChannelData();
     
-    expect(result.channels.length).toBe(2);
-    expect(result.length).toBe(2);
+    expect(result.channels).toHaveLength(2);
+    expect(result).toHaveLength(2);
   });
 
   test('handles Buffer input', () => {
@@ -147,7 +147,7 @@ describe('Int16ArrayWrapper', () => {
       const wrapper = new Int16ArrayWrapper(1, false, buffer);
       const result = wrapper.toChannelData();
       
-      expect(result.channels[0].length).toBe(4);
+      expect(result.channels[0]).toHaveLength(4);
     }
   });
 });
@@ -167,10 +167,10 @@ describe('AudioBufferWrapper', () => {
     const wrapper = new AudioBufferWrapper(mockAudioBuffer);
     const result = wrapper.toChannelData();
     
-    expect(result.channels.length).toBe(2);
+    expect(result.channels).toHaveLength(2);
     expect(result.channels[0]).toEqual(new Float32Array([0.1, 0.2, 0.3]));
     expect(result.channels[1]).toEqual(new Float32Array([0.4, 0.5, 0.6]));
-    expect(result.length).toBe(3);
+    expect(result).toHaveLength(3);
   });
 
   test('exposes length property', () => {
@@ -182,7 +182,7 @@ describe('AudioBufferWrapper', () => {
     
     const wrapper = new AudioBufferWrapper(mockAudioBuffer);
     
-    expect(wrapper.length).toBe(100);
+    expect(wrapper).toHaveLength(100);
   });
 });
 
@@ -398,7 +398,7 @@ describe('BufferQueueNode - Stream Events', () => {
     // Simulate worklet sending close message
     mockWorkletNode.port.onmessage({ data: { type: 'close' } });
     
-    await closePromise;
+    await expect(closePromise).resolves.toBeUndefined();
   });
 
   test('handles closed confirmation from worklet', async () => {
@@ -652,7 +652,7 @@ describe('BufferQueueNode - end() method', () => {
     const finishPromise = new Promise(resolve => node.on('finish', resolve));
     node.end();
     
-    await finishPromise;
+    await expect(finishPromise).resolves.toBeUndefined();
   });
 
   test('calls callback when called without chunk', async () => {

--- a/__tests__/audio/decoder-stream.test.js
+++ b/__tests__/audio/decoder-stream.test.js
@@ -73,7 +73,7 @@ describe('DecoderStream - Initialization', () => {
     
     expect(stream._ended).toBe(false);
     expect(stream._finalized).toBe(false);
-    expect(stream._finalCallback).toBe(null);
+    expect(stream._finalCallback).toBeNull();
     expect(stream._messageId).toBe(0);
   });
 
@@ -210,7 +210,7 @@ describe('DecoderStream - Worker Messages', () => {
         numberOfChannels: 1,
         position: 200
       });
-      expect(chunk.pcm.length).toBe(4);
+      expect(chunk.pcm).toHaveLength(4);
       expect(chunk.pcm[0]).toBeCloseTo(0.1, 5);
       done();
     });
@@ -395,7 +395,7 @@ describe('DecoderStream - Cleanup', () => {
     mockWorker.onmessage({ data: { action: 'reset' } });
 
     expect(mockPool.recycle).toHaveBeenCalledWith(mockWorker);
-    expect(stream._worker).toBe(null);
+    expect(stream._worker).toBeNull();
   });
 
   test('handles missing worker gracefully', () => {
@@ -456,7 +456,7 @@ describe('DecoderStream - Integration', () => {
     mockWorker.onmessage({ data: { action: 'decoded', buffer: new Float32Array(960).buffer, target: 0, numberOfChannels: 1, position: 960 } });
     mockWorker.onmessage({ data: { action: 'decoded', buffer: new Float32Array(960).buffer, target: 0, numberOfChannels: 1, position: 1920 } });
 
-    expect(results.length).toBe(3);
+    expect(results).toHaveLength(3);
     expect(results[0].position).toBe(0);
     expect(results[1].position).toBe(960);
     expect(results[2].position).toBe(1920);
@@ -485,10 +485,10 @@ describe('DecoderStream - Integration', () => {
     mockWorker.onmessage({ data: { action: 'decoded', buffer: new Float32Array(960).buffer, target: 0, numberOfChannels: 1, position: 960 } });
     mockWorker.onmessage({ data: { action: 'decoded', buffer: new Float32Array(960).buffer, target: 0, numberOfChannels: 1, position: 1920 } });
 
-    expect(results.length).toBe(3);
+    expect(results).toHaveLength(3);
     // Second chunk should have null frame in input but still produce output (PLC)
     const nullFrameCall = mockWorker.postMessage.mock.calls[1][0];
-    expect(nullFrameCall.buffer).toBe(null);
+    expect(nullFrameCall.buffer).toBeNull();
   });
 });
 

--- a/__tests__/audio/encode-worker.test.js
+++ b/__tests__/audio/encode-worker.test.js
@@ -127,7 +127,7 @@ describe('encode-worker', () => {
       );
       
       const encodedArg = mockOpusEncoder.encode.mock.calls[0][0];
-      expect(encodedArg.length).toBe(4);
+      expect(encodedArg).toHaveLength(4);
     });
 
     test('posts encoded data with metadata', () => {

--- a/__tests__/audio/encoder-stream.test.js
+++ b/__tests__/audio/encoder-stream.test.js
@@ -188,7 +188,7 @@ describe('EncoderStream - Worker Messages', () => {
         frame: expect.any(Buffer),
         position: 200
       });
-      expect(chunk.frame.length).toBe(50);
+      expect(chunk.frame).toHaveLength(50);
       done();
     });
 
@@ -304,7 +304,7 @@ describe('EncoderStream - Integration', () => {
     mockWorker.onmessage({ data: { buffer: new ArrayBuffer(50), byteOffset: 0, byteLength: 50, target: 0, position: 960 } });
     mockWorker.onmessage({ data: { buffer: new ArrayBuffer(50), byteOffset: 0, byteLength: 50, target: 0, position: 1920 } });
 
-    expect(results.length).toBe(3);
+    expect(results).toHaveLength(3);
     expect(results[0].position).toBe(0);
     expect(results[1].position).toBe(960);
     expect(results[2].position).toBe(1920);

--- a/__tests__/audio/multi-stream.test.js
+++ b/__tests__/audio/multi-stream.test.js
@@ -216,7 +216,7 @@ describe('Multi-Stream Voice Handling', () => {
     );
 
     // Verify all streams were initialized
-    expect(mockBufferQueueNodeInstances.length).toBe(3);
+    expect(mockBufferQueueNodeInstances).toHaveLength(3);
     expect(mockStreamManagerSet).toHaveBeenCalledTimes(3);
     
     // Verify stream manager has 3 active streams

--- a/__tests__/audio/voice.test.js
+++ b/__tests__/audio/voice.test.js
@@ -211,6 +211,7 @@ describe('ContinuousVoiceHandler', () => {
       handler = new ContinuousVoiceHandler(mockClient, settings);
       
       handler.on('started_talking', () => {
+        expect(mockClient.createVoiceStream).toHaveBeenCalled();
         done();
       });
 
@@ -236,7 +237,7 @@ describe('ContinuousVoiceHandler', () => {
       const mockStream = {
         write: jest.fn((data, cb) => {
           expect(data).toBeInstanceOf(Buffer);
-          expect(data.length).toBe(960 * 4);
+          expect(data).toHaveLength(960 * 4);
           cb();
           done();
         }),
@@ -657,7 +658,7 @@ describe('enumMicrophones', () => {
             select.appendChild(option);
           }
         }
-        expect(select.options.length).toBe(2);
+        expect(select.options).toHaveLength(2);
         done();
         return devices;
       });
@@ -854,7 +855,7 @@ describe('initVoice Integration Tests', () => {
         expect(onData).toHaveBeenCalled();
         const callArg = onData.mock.calls[0][0];
         expect(callArg).toBeInstanceOf(Buffer);
-        expect(callArg.length).toBe(960 * 4); // Float32 = 4 bytes per sample
+        expect(callArg).toHaveLength(960 * 4); // Float32 = 4 bytes per sample
       }
     });
 

--- a/__tests__/composables/composables.test.js
+++ b/__tests__/composables/composables.test.js
@@ -372,7 +372,7 @@ describe('vTooltip directive', () => {
       vTooltip.unmounted(mockElement);
       
       // Check tooltip is removed from DOM (parentNode should be null after remove())
-      expect(tooltip.parentNode).toBe(null);
+      expect(tooltip.parentNode).toBeNull();
     });
 
     it('should remove event listeners', () => {

--- a/__tests__/integration/protobuf-serialization.test.js
+++ b/__tests__/integration/protobuf-serialization.test.js
@@ -40,13 +40,13 @@ describe('Protobuf.js Field Name Convention Tests', () => {
 
     test('documents that Protobuf.js converts snake_case → camelCase on incoming', () => {
       // Proto file defines: optional uint32 channel_id = 1;
-      // Protobuf.js converts to: channelId (camelCase)
-      
-      const protoDefinition = 'channel_id';  // In .proto file
-      const jsField = 'channelId';            // In JavaScript after Protobuf.js parsing
-      
-      expect(jsField).not.toBe(protoDefinition);
-      expect(jsField).toBe('channelId');
+      // Protobuf.js converts it to camelCase (channelId) when parsing incoming messages.
+      const decodedPayload = {
+        channelId: 5  // What Protobuf.js actually produces after parsing `channel_id`
+      };
+
+      expect(decodedPayload).toHaveProperty('channelId');
+      expect(decodedPayload).not.toHaveProperty('channel_id');
       
       // This is why our handlers must use:
       // const channelId = payload.channelId ?? payload.channel_id;
@@ -279,10 +279,6 @@ describe('Protobuf.js Field Name Convention Tests', () => {
       if (wrongPattern.hasOwnProperty('self_mute')) {
         // Field exists, but it's the WRONG name
         expect(wrongPattern).not.toHaveProperty('selfMute');
-        
-        // Document the fix needed
-        const fix = 'Change self_mute to selfMute (camelCase)';
-        expect(fix).toBeTruthy();
       }
     });
 

--- a/__tests__/integration/protobuf-structure.test.js
+++ b/__tests__/integration/protobuf-structure.test.js
@@ -296,7 +296,7 @@ describe('Proto Structure Compatibility Tests', () => {
       // In Node.js, protobufjs returns Buffer; in browser, Uint8Array
       // Both are array-like and can be converted with Array.from
       expect(decoded.packet).toBeDefined();
-      expect(decoded.packet.length).toBe(4);
+      expect(decoded.packet).toHaveLength(4);
       expect(Array.from(decoded.packet)).toEqual([0x01, 0x02, 0x03, 0x04]);
     });
   });

--- a/__tests__/integration/server-state-sync.test.js
+++ b/__tests__/integration/server-state-sync.test.js
@@ -219,21 +219,19 @@ describe('Server-State Synchronization - Critical Integration Test', () => {
   });
 
   describe('Documentation: Server as Single Source of Truth', () => {
-    test('Architecture: Server state always wins', () => {
-      // This test documents the architecture decision:
-      // The Mumble server is the SINGLE SOURCE OF TRUTH for user state.
-      // The client UI must ALWAYS reflect what the server thinks.
-      // 
-      // Flow:
-      // 1. User clicks mute button → UI optimistically updates → Send to server
-      // 2. Server processes request → Updates its state → Sends UserState message back
-      // 3. Client receives UserState → Forces UI to match (via server-state-sync)
-      // 
-      // This guarantees:
-      // - No desync between UI and server
-      // - Other clients see correct state
-      // - Server policy (e.g., force-mute) is respected
-      expect(true).toBe(true); // Documentation test
-    });
+    // Architecture decision (no executable assertion applies here):
+    // The Mumble server is the SINGLE SOURCE OF TRUTH for user state.
+    // The client UI must ALWAYS reflect what the server thinks.
+    //
+    // Flow:
+    // 1. User clicks mute button → UI optimistically updates → Send to server
+    // 2. Server processes request → Updates its state → Sends UserState message back
+    // 3. Client receives UserState → Forces UI to match (via server-state-sync)
+    //
+    // This guarantees:
+    // - No desync between UI and server
+    // - Other clients see correct state
+    // - Server policy (e.g., force-mute) is respected
+    test.todo('Architecture: Server state always wins (see comment above)');
   });
 });

--- a/__tests__/mumble-client-client.test.js
+++ b/__tests__/mumble-client-client.test.js
@@ -890,8 +890,9 @@ describe('mumble-client Client', () => {
           linksRemove: [2]
         });
 
-        // The channel2 should have its link to channel1 removed
-        // (via otherChannel._update({ linksRemove: [channelId] }))
+        // channel2 had a link to channel1 (id 1); handleChannelState should
+        // propagate the removal via otherChannel._update({ linksRemove: [channelId] })
+        expect(channel2._links).not.toContain(1);
       });
     });
 

--- a/__tests__/mumble-streams-unit.test.js
+++ b/__tests__/mumble-streams-unit.test.js
@@ -923,7 +923,7 @@ describe('mumble-streams Unit Tests', () => {
         const cipherText = crypt.encrypt(plainText);
 
         // OCB adds 4 bytes: 1 IV byte + 3 tag bytes
-        expect(cipherText.length).toBe(plainText.length + 4);
+        expect(cipherText).toHaveLength(plainText.length + 4);
       });
 
       test('encryption changes IV', () => {
@@ -1005,9 +1005,9 @@ describe('mumble-streams Unit Tests', () => {
         await generateKeyAsync(crypt);
         
         expect(crypt.ready()).toBeTruthy();
-        expect(crypt.getKey().length).toBe(16);
-        expect(crypt.getEncryptIV().length).toBe(16);
-        expect(crypt.getDecryptIV().length).toBe(16);
+        expect(crypt.getKey()).toHaveLength(16);
+        expect(crypt.getEncryptIV()).toHaveLength(16);
+        expect(crypt.getDecryptIV()).toHaveLength(16);
       });
 
       test('generates different keys on each call', async () => {

--- a/__tests__/mumble-streams/mumble-proto-minimal.test.js
+++ b/__tests__/mumble-streams/mumble-proto-minimal.test.js
@@ -369,7 +369,7 @@ describe('MumbleProto', () => {
       const encoded = BanList.encode(original).finish();
       const decoded = BanList.decode(encoded);
       
-      expect(decoded.bans.length).toBe(1);
+      expect(decoded.bans).toHaveLength(1);
       expect(decoded.bans[0].name).toBe('BadUser');
       expect(decoded.bans[0].mask).toBe(32);
       expect(decoded.query).toBe(true);
@@ -506,9 +506,9 @@ describe('MumbleProto', () => {
       const decoded = ACL.decode(encoded);
       
       expect(decoded.channelId).toBe(1);
-      expect(decoded.groups.length).toBe(1);
+      expect(decoded.groups).toHaveLength(1);
       expect(decoded.groups[0].name).toBe('admin');
-      expect(decoded.acls.length).toBe(1);
+      expect(decoded.acls).toHaveLength(1);
       expect(decoded.acls[0].grant).toBe(255);
     });
 
@@ -666,7 +666,7 @@ describe('MumbleProto', () => {
       const encoded = UserList.encode(original).finish();
       const decoded = UserList.decode(encoded);
       
-      expect(decoded.users.length).toBe(2);
+      expect(decoded.users).toHaveLength(2);
       expect(decoded.users[0].name).toBe('User1');
       expect(decoded.users[1].userId).toBe(2);
     });
@@ -711,7 +711,7 @@ describe('MumbleProto', () => {
       const decoded = VoiceTarget.decode(encoded);
       
       expect(decoded.id).toBe(1);
-      expect(decoded.targets.length).toBe(1);
+      expect(decoded.targets).toHaveLength(1);
       expect(decoded.targets[0].session).toEqual([1, 2]);
     });
 
@@ -1214,7 +1214,7 @@ describe('MumbleProto', () => {
       const encoded = UserStats.encode(original).finish();
       const decoded = UserStats.decode(encoded);
       
-      expect(decoded.certificates.length).toBe(2);
+      expect(decoded.certificates).toHaveLength(2);
       expect(decoded.fromClient.late).toBe(5);
       expect(decoded.fromServer.lost).toBe(1);
       expect(decoded.version.os).toBe('Linux');

--- a/__tests__/mumble-streams/udp-crypto.test.js
+++ b/__tests__/mumble-streams/udp-crypto.test.js
@@ -331,7 +331,7 @@ describe('UdpCrypt', () => {
       
       const encrypted = crypt1.encrypt(plainText);
       expect(encrypted).not.toBeNull();
-      expect(encrypted.length).toBe(plainText.length + 4);
+      expect(encrypted).toHaveLength(plainText.length + 4);
       
       const decrypted = crypt2.decrypt(encrypted);
       expect(decrypted).not.toBeNull();

--- a/__tests__/regression/protobuf-camelcase.test.js
+++ b/__tests__/regression/protobuf-camelcase.test.js
@@ -165,12 +165,6 @@ describe('Protobuf camelCase Field Name Regression Tests', () => {
       expect(visited.has(channelId)).toBe(false);
       visited.add(channelId);
       expect(visited.has(channelId)).toBe(true);
-      
-      // Second visit should be detected
-      if (visited.has(channelId)) {
-        // Should return early to prevent infinite recursion
-        expect(true).toBe(true);
-      }
     });
   });
 

--- a/__tests__/stores/audioStore.test.js
+++ b/__tests__/stores/audioStore.test.js
@@ -400,7 +400,7 @@ describe('audioStore', () => {
       
       const result = await store.initializePersistentBeeper();
       
-      expect(result).toBe(null);
+      expect(result).toBeNull();
       expect(store.beeperReady.value).toBe(false);
     });
 
@@ -412,7 +412,7 @@ describe('audioStore', () => {
       
       const result = await store.initializePersistentBeeper();
       
-      expect(result).toBe(null);
+      expect(result).toBeNull();
       expect(store.beeperReady.value).toBe(false);
     });
 

--- a/__tests__/stores/userStore.test.js
+++ b/__tests__/stores/userStore.test.js
@@ -604,7 +604,7 @@ describe('useUserStore Request Methods Branch Coverage', () => {
       userStore.reset();
       
       // After reset, thisUser becomes null (ref gets replaced)
-      expect(userStore.thisUser).toBe(null);
+      expect(userStore.thisUser).toBeNull();
       expect(userStore.selfMute).toBe(false);
       expect(userStore.selfDeaf).toBe(false);
     });

--- a/__tests__/utils/connect-address.test.js
+++ b/__tests__/utils/connect-address.test.js
@@ -1,0 +1,61 @@
+import { resolveConnectAddress } from '../../app/utils/connect-address.js';
+
+describe('resolveConnectAddress', () => {
+  describe('no query override (regression: trust configured defaults)', () => {
+    it('uses the operator-configured default when no query param is present', () => {
+      const result = resolveConnectAddress(null, 'voice.example.com', ['app.example.com']);
+
+      expect(result).toEqual({ address: 'voice.example.com', rejected: false });
+    });
+
+    it('trusts a default address even when it differs from the allowlist/hostname', () => {
+      // Regression: a deployment can point at a dedicated Mumble host that is
+      // NOT the page's own hostname and has no `allowedServerHosts` configured.
+      // This must still work - only the URL query param is untrusted, not the
+      // operator-configured default.
+      const result = resolveConnectAddress(undefined, 'voice.example.com', ['app.example.com']);
+
+      expect(result).toEqual({ address: 'voice.example.com', rejected: false });
+    });
+
+    it('returns no address when neither a query param nor a default is set', () => {
+      const result = resolveConnectAddress('', undefined, ['app.example.com']);
+
+      expect(result).toEqual({ address: undefined, rejected: false });
+    });
+  });
+
+  describe('query override matches the allowlist', () => {
+    it('accepts a query address that is in the allowlist', () => {
+      const result = resolveConnectAddress('app.example.com', 'voice.example.com', ['app.example.com']);
+
+      expect(result).toEqual({ address: 'app.example.com', rejected: false });
+    });
+
+    it('accepts a query address matching the page hostname fallback allowlist', () => {
+      const result = resolveConnectAddress('mumble.local', undefined, ['mumble.local']);
+
+      expect(result).toEqual({ address: 'mumble.local', rejected: false });
+    });
+  });
+
+  describe('query override rejected (security fix: connection hijacking / CWE-346)', () => {
+    it('rejects an attacker-crafted address not in the allowlist', () => {
+      const result = resolveConnectAddress('evil.attacker.com', 'voice.example.com', ['app.example.com']);
+
+      expect(result).toEqual({ address: undefined, rejected: true });
+    });
+
+    it('does not fall back to the configured default when the query override is rejected', () => {
+      const result = resolveConnectAddress('evil.attacker.com', 'voice.example.com', ['app.example.com']);
+
+      expect(result.address).toBeUndefined();
+    });
+
+    it('rejects when no allowlist matches and no allowedServerHosts is configured', () => {
+      const result = resolveConnectAddress('evil.attacker.com', undefined, ['app.example.com']);
+
+      expect(result).toEqual({ address: undefined, rejected: true });
+    });
+  });
+});

--- a/__tests__/utils/duplexer-lite.test.js
+++ b/__tests__/utils/duplexer-lite.test.js
@@ -75,8 +75,10 @@ describe('duplexer-lite', () => {
       
       // Fill the duplex buffer to trigger backpressure
 
+      let pauseCallCount = 0;
       const origPause = readable.pause.bind(readable);
       readable.pause = () => {
+        pauseCallCount++;
         return origPause();
       };
       
@@ -86,6 +88,7 @@ describe('duplexer-lite', () => {
       }
       
       setTimeout(() => {
+        expect(pauseCallCount).toBeGreaterThan(0);
         // Drain the duplex to trigger resume
         duplex.resume();
         done();
@@ -101,6 +104,7 @@ describe('duplexer-lite', () => {
       const duplex = duplexer(writable, readable);
       
       duplex.on('end', () => {
+        expect(duplex.readableEnded).toBe(true);
         done();
       });
       
@@ -115,6 +119,7 @@ describe('duplexer-lite', () => {
       const duplex = duplexer(writable, readable);
       
       writable.on('finish', () => {
+        expect(writable.writableFinished).toBe(true);
         done();
       });
       

--- a/__tests__/utils/frequency-analyzer.test.js
+++ b/__tests__/utils/frequency-analyzer.test.js
@@ -306,7 +306,7 @@ describe('Frequency Analyzer', () => {
       // Should not analyze when muted
       const callsBeforeMute = mockAnalyserNode.getByteFrequencyData.mock.calls.length;
       jest.advanceTimersByTime(100);
-      expect(mockAnalyserNode.getByteFrequencyData.mock.calls.length).toBe(callsBeforeMute);
+      expect(mockAnalyserNode.getByteFrequencyData.mock.calls).toHaveLength(callsBeforeMute);
     });
   });
 

--- a/__tests__/utils/stream-utils.test.js
+++ b/__tests__/utils/stream-utils.test.js
@@ -132,6 +132,7 @@ describe('websocket-stream-lite', () => {
     const stream = websocketStream('wss://example.com');
     
     stream.on('connect', () => {
+      expect(stream.destroyed).toBe(false);
       done();
     });
     
@@ -143,6 +144,7 @@ describe('websocket-stream-lite', () => {
     const stream = websocketStream(mockSocket);
     
     stream.on('connect', () => {
+      expect(stream.destroyed).toBe(false);
       done();
     });
   });
@@ -154,6 +156,7 @@ describe('websocket-stream-lite', () => {
     stream.on('data', () => {});
     
     stream.on('end', () => {
+      expect(stream.readableEnded).toBe(true);
       done();
     });
     
@@ -228,6 +231,7 @@ describe('duplexer-lite', () => {
     duplex.on('data', () => {}); // consume data
     
     duplex.on('end', () => {
+      expect(duplex.readableEnded).toBe(true);
       done();
     });
     
@@ -240,6 +244,7 @@ describe('duplexer-lite', () => {
     const duplex = duplexer(writable, readable);
     
     writable.on('finish', () => {
+      expect(writable.writableFinished).toBe(true);
       done();
     });
     
@@ -288,7 +293,10 @@ describe('duplexer-lite', () => {
         writeCount++;
       } else {
         clearInterval(interval);
-        duplex.end(() => done());
+        duplex.end(() => {
+          expect(writeCount).toBe(5);
+          done();
+        });
       }
     }, 5);
   });
@@ -368,10 +376,10 @@ describe('chunker-lite', () => {
     stream.on('data', (chunk) => chunks.push(chunk));
     stream.on('end', () => {
       // "hello world" = 11 bytes, chunks of 4 = 4, 4, 3
-      expect(chunks.length).toBe(3);
-      expect(chunks[0].length).toBe(4);
-      expect(chunks[1].length).toBe(4);
-      expect(chunks[2].length).toBe(3); // Remaining (11 - 8 = 3)
+      expect(chunks).toHaveLength(3);
+      expect(chunks[0]).toHaveLength(4);
+      expect(chunks[1]).toHaveLength(4);
+      expect(chunks[2]).toHaveLength(3); // Remaining (11 - 8 = 3)
       done();
     });
     
@@ -386,9 +394,9 @@ describe('chunker-lite', () => {
     
     stream.on('data', (chunk) => chunks.push(chunk));
     stream.on('end', () => {
-      expect(chunks.length).toBe(2);
-      expect(chunks[0].length).toBe(4);
-      expect(chunks[1].length).toBe(4);
+      expect(chunks).toHaveLength(2);
+      expect(chunks[0]).toHaveLength(4);
+      expect(chunks[1]).toHaveLength(4);
       done();
     });
     
@@ -402,7 +410,7 @@ describe('chunker-lite', () => {
     
     stream.on('data', (chunk) => chunks.push(chunk));
     stream.on('end', () => {
-      expect(chunks.length).toBe(1);
+      expect(chunks).toHaveLength(1);
       expect(chunks[0].toString()).toBe('small');
       done();
     });
@@ -516,6 +524,7 @@ describe('drop-stream', () => {
     const stream = new DropStream();
     
     stream.on('finish', () => {
+      expect(stream.writableFinished).toBe(true);
       done();
     });
     

--- a/__tests__/worker-client.test.js
+++ b/__tests__/worker-client.test.js
@@ -87,7 +87,7 @@ describe('WorkerBasedMumbleConnector', () => {
     });
 
     test('attaches message listener', () => {
-      expect(mockWorker.listeners.message.length).toBe(1);
+      expect(mockWorker.listeners.message).toHaveLength(1);
     });
   });
 
@@ -165,7 +165,7 @@ describe('WorkerBasedMumbleConnector', () => {
       const reqId = connector._reqId - 1;
 
       expect(connector._requests[reqId]).toBeDefined();
-      expect(connector._requests[reqId].length).toBe(2);
+      expect(connector._requests[reqId]).toHaveLength(2);
     });
 
     test('resolves promise on successful response', async () => {
@@ -552,7 +552,7 @@ describe('WorkerBasedMumbleClient', () => {
       client._user('user-2');
 
       const users = client.users;
-      expect(users.length).toBe(2);
+      expect(users).toHaveLength(2);
     });
   });
 
@@ -585,7 +585,7 @@ describe('WorkerBasedMumbleClient', () => {
       client._channel('channel-2');
 
       const channels = client.channels;
-      expect(channels.length).toBe(2);
+      expect(channels).toHaveLength(2);
     });
   });
 
@@ -742,7 +742,7 @@ describe('WorkerBasedMumbleChannel', () => {
     test('_setProp resolves link IDs to channel objects', () => {
       channel._setProp('links', ['link1', 'link2']);
 
-      expect(channel.links.length).toBe(2);
+      expect(channel.links).toHaveLength(2);
       expect(channel.links[0]._id).toBe('link1');
     });
 
@@ -777,7 +777,7 @@ describe('WorkerBasedMumbleChannel', () => {
 
       const children = channel.children;
 
-      expect(children.length).toBe(2);
+      expect(children).toHaveLength(2);
       expect(children).toContain(child1);
       expect(children).toContain(child2);
     });

--- a/__tests__/worker.test.js
+++ b/__tests__/worker.test.js
@@ -686,6 +686,7 @@ describe("worker.js", () => {
       
       messageHandler({ data: { clientId, userId: 42, method: "sendMessage", payload: ["test"] } });
       
+      expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
     });
   });
@@ -695,20 +696,32 @@ describe("worker.js", () => {
       const { client, clientId } = await connectClient();
       const mockStream = new MockPassThrough();
       client.createVoiceStream.mockReturnValue(mockStream);
+      const writeSpy = jest.spyOn(MockPassThrough.prototype, 'write');
 
       messageHandler({ data: { clientId, method: "createVoiceStream", payload: [5, 960, 0] } });
       
       const voiceData = new ArrayBuffer(960 * 4);
       messageHandler({ data: { voiceId: 5, chunk: voiceData } });
+
+      // handleVoiceStream writes to the internal resampler (a PassThrough),
+      // which then pipes through chunker/transform stages to the user stream.
+      expect(writeSpy).toHaveBeenCalledTimes(1);
+      expect(writeSpy.mock.calls[0][0]).toHaveLength(960 * 4);
+      writeSpy.mockRestore();
     });
 
     test("should end voice stream when chunk is null", async () => {
       const { client, clientId } = await connectClient();
       const mockStream = new MockPassThrough();
       client.createVoiceStream.mockReturnValue(mockStream);
+      const endSpy = jest.spyOn(MockPassThrough.prototype, 'end');
 
       messageHandler({ data: { clientId, method: "createVoiceStream", payload: [6, 960, 0] } });
       messageHandler({ data: { voiceId: 6, chunk: null } });
+
+      // handleVoiceStream ends the internal resampler (a PassThrough) when chunk is null
+      expect(endSpy).toHaveBeenCalledTimes(1);
+      endSpy.mockRestore();
     });
   });
 });

--- a/app/components/ConnectDialog.vue
+++ b/app/components/ConnectDialog.vue
@@ -124,7 +124,7 @@
           type="button"
           class="dialog-logout-button"
           @click="handleLogout"
-          :aria-label="translate('connectdialog.logout') + ' of application'"
+          :aria-label="translate('connectdialog.logout')"
         >
           {{ translate('connectdialog.logout') }}
         </button>

--- a/app/components/ConnectDialog.vue
+++ b/app/components/ConnectDialog.vue
@@ -117,14 +117,14 @@
           type="submit"
           class="connect-dialog-submit"
           :value="isTestActive && connected ? 'Exit Test & Connect' : 'Connect'"
-          :aria-label="isTestActive && connected ? 'Exit test mode and connect to voice server' : 'Connect to voice server'"
+          :aria-label="(isTestActive && connected ? 'Exit Test & Connect' : 'Connect') + ' to voice server'"
         />
         <button
           v-if="auth?.logout && username"
           type="button"
           class="dialog-logout-button"
           @click="handleLogout"
-          aria-label="Log out of application"
+          :aria-label="translate('connectdialog.logout') + ' of application'"
         >
           {{ translate('connectdialog.logout') }}
         </button>

--- a/app/components/ConnectErrorDialog.vue
+++ b/app/components/ConnectErrorDialog.vue
@@ -48,7 +48,7 @@
             </td>
           </tr>
           <tr v-if="type === 2 || type === 3 || type === 5">
-            <td class="alternate-username">{{ translate('connectdialog.username') }}</td>
+            <td class="alternate-username"><label for="alternate-username">{{ translate('connectdialog.username') }}</label></td>
             <td>
               <input
                 id="alternate-username"
@@ -60,7 +60,7 @@
             </td>
           </tr>
           <tr v-if="type === 3 || type === 4">
-            <td class="alternate-password">{{ translate('connectdialog.password') }}</td>
+            <td class="alternate-password"><label for="alternate-password">{{ translate('connectdialog.password') }}</label></td>
             <td>
               <input
                 id="alternate-password"

--- a/app/composables/useConnectionLogic.js
+++ b/app/composables/useConnectionLogic.js
@@ -7,7 +7,7 @@ import { useSettingsStore } from '../stores/settingsStore';
 import { useDialogStore } from '../stores/dialogStore';
 import { translate } from '../localize';
 import { fetchCredentials } from '../auth/credentials-service.js';
-import { getGuacamoleLogin, getGuacamoleCredentials, setupGuacamoleFrame } from './useGuacamole';
+import { getGuacamoleLogin, getGuacamoleCredentials, startGuacamoleFrame, notifyGuacamoleUnavailable } from './useGuacamole';
 import { registerExistingUsers, resetUIForConnection } from './useMumbleHelpers';
 
 /**
@@ -227,8 +227,14 @@ export function useConnectionLogic({ auth } = {}) {
   }
 
   function _initializeGuacamole(serverCredentials, password) {
+    if (voiceStore.isLoopbackMode) return;
+
     const guacCreds = getGuacamoleCredentials(serverCredentials, password, auth);
-    setupGuacamoleFrame(guacCreds.user, guacCreds.password, voiceStore.isLoopbackMode, uiStore);
+    if (guacCreds.user) {
+      startGuacamoleFrame(guacCreds.user, guacCreds.password, uiStore);
+    } else {
+      notifyGuacamoleUnavailable();
+    }
   }
 
   function _initializeClientState(client) {

--- a/app/composables/useGuacamole.js
+++ b/app/composables/useGuacamole.js
@@ -26,19 +26,21 @@ export function getGuacamoleCredentials(serverCredentials, password, auth) {
 }
 
 /**
- * Setup Guacamole frame if needed
- * @param {string|false} guac_login
+ * Start the Guacamole remote-desktop frame for an authorized user.
+ * @param {string} guac_login
  * @param {string} password
- * @param {boolean} isLoopbackMode
  * @param {Object} uiStore
  */
-export function setupGuacamoleFrame(guac_login, password, isLoopbackMode, uiStore) {
-  if (guac_login && !isLoopbackMode) {
-    if (uiStore.guacamoleFrame) {
-      uiStore.guacamoleFrame.start(guac_login, password);
-      uiStore.guacamoleFrame.show();
-    }
-  } else if (!guac_login && !isLoopbackMode) {
-    alert('For visual access please ask your administrator.');
+export function startGuacamoleFrame(guac_login, password, uiStore) {
+  if (uiStore.guacamoleFrame) {
+    uiStore.guacamoleFrame.start(guac_login, password);
+    uiStore.guacamoleFrame.show();
   }
+}
+
+/**
+ * Notify the user that visual access is unavailable (no Guacamole role).
+ */
+export function notifyGuacamoleUnavailable() {
+  alert('For visual access please ask your administrator.');
 }

--- a/app/index.html
+++ b/app/index.html
@@ -100,7 +100,7 @@
     <script>
       (function() {
         if (/^#(recovery_token|confirmation_token|invite_token)=/.test(location.hash)) {
-          window.__savedIdentityHash = location.hash;
+          globalThis.__savedIdentityHash = location.hash;
           history.replaceState(null, '', location.pathname + location.search);
         }
       })();

--- a/app/index.js
+++ b/app/index.js
@@ -17,6 +17,7 @@ import {
 import {
   translate,
 } from "./localize";
+import { resolveConnectAddress } from "./utils/connect-address.js";
 
 // Check URL parameters for debug-audio flag (used in automated tests)
 const urlParams = new URLSearchParams(globalThis.location.search);
@@ -133,27 +134,27 @@ function applyQueryParamsToConnectDialog() {
   let queryParams = Object.fromEntries(urlObj.searchParams.entries());
   queryParams = { ...globalThis.mumbleWebConfig.defaults, ...queryParams };
   
-  if (queryParams.address) {
-    // SECURITY: The address is used to open a WebSocket connection to the
-    // Mumble server. Only the raw URL query parameter is untrusted input from
-    // the page visitor; `mumbleWebConfig.defaults.address` (merged in above)
-    // is operator-configured and always trusted. Validate the URL-supplied
-    // value against an allowlist (or this page's own hostname) before using
-    // it, otherwise an attacker-crafted link could hijack the streaming
-    // connection to a server they control (CWE-346 / connection hijacking).
-    const addressFromQuery = urlObj.searchParams.get('address');
-    if (addressFromQuery) {
-      const allowedHosts = globalThis.mumbleWebConfig.allowedServerHosts || [globalThis.location.hostname];
-      if (allowedHosts.includes(addressFromQuery)) {
-        dialogStore.connectDialog.address = addressFromQuery;
-      } else {
-        console.warn('[SECURITY] Ignoring untrusted "address" query parameter:', addressFromQuery);
-      }
-    } else {
-      // No query override - this is the operator-configured default, which is trusted.
-      dialogStore.connectDialog.address = queryParams.address;
-    }
+  // SECURITY: The address is used to open a WebSocket connection to the
+  // Mumble server. Only the raw URL query parameter is untrusted input from
+  // the page visitor; `mumbleWebConfig.defaults.address` is operator-
+  // configured and always trusted. See resolveConnectAddress() for the
+  // allowlisting logic that prevents an attacker-crafted link from
+  // hijacking the streaming connection to a server they control
+  // (CWE-346 / connection hijacking).
+  const allowedHosts = globalThis.mumbleWebConfig.allowedServerHosts || [globalThis.location.hostname];
+  const addressFromQuery = urlObj.searchParams.get('address');
+  const { address, rejected } = resolveConnectAddress(
+    addressFromQuery,
+    globalThis.mumbleWebConfig.defaults?.address,
+    allowedHosts
+  );
+  if (rejected) {
+    console.warn('[SECURITY] Ignoring untrusted "address" query parameter:', addressFromQuery);
   }
+  if (address) {
+    dialogStore.connectDialog.address = address;
+  }
+
   if (queryParams.port) {
     dialogStore.connectDialog.port = queryParams.port;
   }

--- a/app/index.js
+++ b/app/index.js
@@ -135,15 +135,23 @@ function applyQueryParamsToConnectDialog() {
   
   if (queryParams.address) {
     // SECURITY: The address is used to open a WebSocket connection to the
-    // Mumble server. Only accept it if it matches an explicitly configured
-    // allowlist (or falls back to this page's own hostname); otherwise an
-    // attacker-crafted link could hijack the streaming connection to a
-    // server they control (CWE-346 / connection hijacking).
-    const allowedHosts = globalThis.mumbleWebConfig.allowedServerHosts || [globalThis.location.hostname];
-    if (allowedHosts.includes(queryParams.address)) {
-      dialogStore.connectDialog.address = queryParams.address;
+    // Mumble server. Only the raw URL query parameter is untrusted input from
+    // the page visitor; `mumbleWebConfig.defaults.address` (merged in above)
+    // is operator-configured and always trusted. Validate the URL-supplied
+    // value against an allowlist (or this page's own hostname) before using
+    // it, otherwise an attacker-crafted link could hijack the streaming
+    // connection to a server they control (CWE-346 / connection hijacking).
+    const addressFromQuery = urlObj.searchParams.get('address');
+    if (addressFromQuery) {
+      const allowedHosts = globalThis.mumbleWebConfig.allowedServerHosts || [globalThis.location.hostname];
+      if (allowedHosts.includes(addressFromQuery)) {
+        dialogStore.connectDialog.address = addressFromQuery;
+      } else {
+        console.warn('[SECURITY] Ignoring untrusted "address" query parameter:', addressFromQuery);
+      }
     } else {
-      console.warn('[SECURITY] Ignoring untrusted "address" query parameter:', queryParams.address);
+      // No query override - this is the operator-configured default, which is trusted.
+      dialogStore.connectDialog.address = queryParams.address;
     }
   }
   if (queryParams.port) {

--- a/app/index.js
+++ b/app/index.js
@@ -134,7 +134,17 @@ function applyQueryParamsToConnectDialog() {
   queryParams = { ...globalThis.mumbleWebConfig.defaults, ...queryParams };
   
   if (queryParams.address) {
-    dialogStore.connectDialog.address = queryParams.address;
+    // SECURITY: The address is used to open a WebSocket connection to the
+    // Mumble server. Only accept it if it matches an explicitly configured
+    // allowlist (or falls back to this page's own hostname); otherwise an
+    // attacker-crafted link could hijack the streaming connection to a
+    // server they control (CWE-346 / connection hijacking).
+    const allowedHosts = globalThis.mumbleWebConfig.allowedServerHosts || [globalThis.location.hostname];
+    if (allowedHosts.includes(queryParams.address)) {
+      dialogStore.connectDialog.address = queryParams.address;
+    } else {
+      console.warn('[SECURITY] Ignoring untrusted "address" query parameter:', queryParams.address);
+    }
   }
   if (queryParams.port) {
     dialogStore.connectDialog.port = queryParams.port;

--- a/app/index.js
+++ b/app/index.js
@@ -141,7 +141,15 @@ function applyQueryParamsToConnectDialog() {
   // allowlisting logic that prevents an attacker-crafted link from
   // hijacking the streaming connection to a server they control
   // (CWE-346 / connection hijacking).
-  const allowedHosts = globalThis.mumbleWebConfig.allowedServerHosts || [globalThis.location.hostname];
+  // Config values can arrive as a non-array (e.g. a single string from JSON/env
+  // config); coerce here so resolveConnectAddress()'s `.includes()` check is
+  // always an array membership test, never a substring match.
+  const configuredHosts = globalThis.mumbleWebConfig.allowedServerHosts;
+  const allowedHosts = Array.isArray(configuredHosts)
+    ? configuredHosts
+    : configuredHosts
+      ? [configuredHosts]
+      : [globalThis.location.hostname];
   const addressFromQuery = urlObj.searchParams.get('address');
   const { address, rejected } = resolveConnectAddress(
     addressFromQuery,

--- a/app/utils/connect-address.js
+++ b/app/utils/connect-address.js
@@ -1,0 +1,28 @@
+/**
+ * Resolve the trusted "address" (Mumble server host) for the connect dialog.
+ *
+ * The `address` URL query parameter is attacker-controllable via a crafted
+ * link (e.g. `?address=evil.example.com`) and, if used unchecked, could
+ * redirect the app's streaming WebSocket connection to a server the
+ * attacker controls (CWE-346 / connection hijacking). A configured
+ * `defaultAddress` (e.g. `mumbleWebConfig.defaults.address`) is set by the
+ * deployment operator and is always trusted, even if it differs from the
+ * page's own hostname (e.g. a dedicated Mumble host).
+ *
+ * @param {string|null|undefined} addressFromQuery - raw `?address=` value from the URL,
+ *   or null/undefined/empty if not present in the query string
+ * @param {string|undefined} defaultAddress - operator-configured default address
+ * @param {string[]} allowedHosts - hosts the query param is allowed to target
+ * @returns {{ address: string|undefined, rejected: boolean }}
+ *   `address`: the value to apply (undefined means "leave unchanged")
+ *   `rejected`: true if an untrusted query override was ignored
+ */
+export function resolveConnectAddress(addressFromQuery, defaultAddress, allowedHosts) {
+  if (!addressFromQuery) {
+    return { address: defaultAddress, rejected: false };
+  }
+  if (allowedHosts.includes(addressFromQuery)) {
+    return { address: addressFromQuery, rejected: false };
+  }
+  return { address: undefined, rejected: true };
+}

--- a/auth-server/server.py
+++ b/auth-server/server.py
@@ -103,7 +103,7 @@ def get_nested_property(obj: dict, path: str) -> Any:
     return result
 
 
-def get_guacamole_user(roles: list) -> str:
+def get_guacamole_user(roles: Any) -> str:
     """Determine Guacamole user from roles."""
     if not roles or not isinstance(roles, list):
         return 'watcher'
@@ -150,7 +150,7 @@ def _execute_auth_request(url: str, token: str) -> Optional[dict]:
             return None
         except urllib.error.URLError as e:
             print(f'[AUTH] Token validation network error on attempt {attempt + 1}: {e.reason}')
-        except (json.JSONDecodeError, TimeoutError, OSError) as e:
+        except (json.JSONDecodeError, OSError) as e:
             print(f'[AUTH] Token validation error on attempt {attempt + 1}: {e}')
 
         if attempt == max_retries - 1:
@@ -189,7 +189,7 @@ def validate_token(token: str, provider_config: dict) -> Optional[dict]:
 
 
 
-def hash_email(email: str) -> str:
+def hash_email(email: Optional[str]) -> str:
     """Hash email for privacy-compliant logging (GDPR/CCPA)."""
     if not email:
         return 'unknown'

--- a/auth-server/test_server.py
+++ b/auth-server/test_server.py
@@ -147,34 +147,34 @@ class TestRateLimiting(unittest.TestCase):
         rate_limiter.store.clear()
 
     def test_allows_first_request(self):
-        self.assertTrue(rate_limiter.check('192.168.1.1'))
+        self.assertTrue(rate_limiter.check('203.0.113.1'))
 
     def test_allows_multiple_requests_under_limit(self):
         for _ in range(rate_limiter.max_requests - 1):
-            self.assertTrue(rate_limiter.check('192.168.1.2'))
+            self.assertTrue(rate_limiter.check('203.0.113.2'))
 
     def test_blocks_after_limit(self):
         for _ in range(rate_limiter.max_requests):
-            rate_limiter.check('192.168.1.3')
-        self.assertFalse(rate_limiter.check('192.168.1.3'))
+            rate_limiter.check('203.0.113.3')
+        self.assertFalse(rate_limiter.check('203.0.113.3'))
 
     def test_different_ips_independent(self):
         for _ in range(rate_limiter.max_requests):
-            rate_limiter.check('192.168.1.4')
+            rate_limiter.check('203.0.113.4')
         # Different IP should still be allowed
-        self.assertTrue(rate_limiter.check('192.168.1.5'))
+        self.assertTrue(rate_limiter.check('203.0.113.5'))
 
     def test_old_requests_expire(self):
         # Fill up rate limit
         for _ in range(rate_limiter.max_requests):
-            rate_limiter.check('192.168.1.6')
+            rate_limiter.check('203.0.113.6')
         
         # Simulate time passing
         old_time = time() - rate_limiter.window - 1
-        rate_limiter.store['192.168.1.6'] = [old_time] * rate_limiter.max_requests
+        rate_limiter.store['203.0.113.6'] = [old_time] * rate_limiter.max_requests
         
         # Should be allowed again
-        self.assertTrue(rate_limiter.check('192.168.1.6'))
+        self.assertTrue(rate_limiter.check('203.0.113.6'))
 
 
 class TestAuthProviderConfig(unittest.TestCase):


### PR DESCRIPTION
## Summary

Resolves all currently open SonarQube findings on `lite` (98 issues).

### Security & bugs
- `app/index.js`: allowlist the `address` query param before assigning it to `connectDialog.address` to prevent WebSocket connection hijacking via crafted links (`jssecurity:S8480` / CWE-346)
- `auth-server/server.py`: remove redundant `TimeoutError` from except tuple, already covered by `OSError` (`python:S5713`)
- `auth-server/server.py`: widen `get_guacamole_user`/`hash_email` type hints to match their defensive runtime behavior (`python:S5655`)
- `auth-server/test_server.py`: use RFC 5737 documentation IPs instead of private RFC1918 addresses in test fixtures (`python:S1313`)

### Accessibility
- `app/components/ConnectDialog.vue`: make submit/logout button `aria-label`s contain their visible text (`Web:S7927`)
- `app/components/ConnectErrorDialog.vue`: associate `<label for>` with the alternate username/password inputs (`Web:InputWithoutLabelCheck`)

### Code quality
- `app/index.html`: use `globalThis` instead of `window` (`javascript:S7764`)
- `app/composables/useGuacamole.js` + `useConnectionLogic.js`: split boolean-flag-controlled `setupGuacamoleFrame()` into `startGuacamoleFrame()`/`notifyGuacamoleUnavailable()` (`javascript:S2301`)

### Test quality (`__tests__/**`)
- Replace generic assertions (`expect(x.length).toBe(n)`, `expect(x).toBe(null)`) with `toHaveLength()`/`toBeNull()` (`javascript:S5906`)
- Add real assertions to test cases that previously only awaited a promise or called `done()` without checking anything (`javascript:S2699`)
- Replace tautological assertions (`expect(true).toBe(true)`, literal-vs-literal comparisons) with genuine checks (`javascript:S5914`)

## Testing
- `npm run test:unit` → 1769 tests passed (1 todo)
- `python3 auth-server/test_server.py -v` → 40 tests passed

## Notes
Two `python:S5332` "insecure HTTP" hotspots in `auth-server/server.py` and a handful of local SonarLint findings (`javascript:S1848`, `javascript:S7721`) were intentionally left untouched — they are already reviewed/closed as safe/false-positive in SonarQube.