### PR TITLE
docs: align auth migration instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,14 +209,16 @@ Console log prefixes: `[VOICE]`, `[DEBUG-WORKER]`, `[DEBUG-DECODER]`, `[LOOPBACK
 
 ## 🔐 Authentication
 
-Auth abstraction layer supports provider migration (Netlify Identity → Supabase).
+The current implementation uses Netlify Identity. Auth0 is the decided target for the Flexpair hub-login migration, but Auth0 support is not implemented in this submodule and this file is not the migration authority.
 
 - Config: `app/config.js` → `auth.provider` setting
-- Adapters: `app/auth/NetlifyIdentityAdapter.js`, future `SupabaseAuthAdapter.js`
-- See `app/auth/README.md` for migration plan
+- Current adapter: `app/auth/NetlifyIdentityAdapter.js`
+- See `app/auth/README.md` for the current implementation boundary.
+- For an explicit Auth0/Corporate-IdP migration request, return to the Flexpair umbrella root and read `AGENTS.md`, `AUTH0-MIGRATION-RUNBOOK.md`, `AUTH0-MIGRATION-PLAN.md`, and decisions A-12, A-14, and A-15 in `DECISIONS.md` before changing this submodule.
+- Keep the current Netlify identity, invite, recovery, proxy, and rollback paths available until the umbrella acceptance matrix authorises otherwise. Do not follow stale Supabase migration instructions.
 
 ## 📚 Related Docs
 - `app/stores/README.md` – Pinia architecture diagrams
-- `app/audio/README.md` – Audio debugging guide  
-- `app/auth/README.md` – Auth abstraction (Netlify → Supabase migration)
+- `app/audio/README.md` – Audio debugging guide
+- `app/auth/README.md` – Current Netlify auth abstraction and migration boundary
 - `tests/README.md` – Testing strategy, multi-stream tests

--- a/app/auth/README.md
+++ b/app/auth/README.md
@@ -4,15 +4,19 @@ Provider-agnostic authentication system for mumbling-mole.
 
 ## Purpose
 
-This authentication abstraction layer provides a unified interface for different authentication providers. The current production provider is **[Netlify](https://en.wikipedia.org/wiki/Netlify) Identity**. The abstraction enables future migration to other auth services without changing application code.
+This authentication abstraction layer provides a unified interface for different authentication providers. The current production provider is **[Netlify](https://en.wikipedia.org/wiki/Netlify) Identity**. The abstraction is the intended integration boundary for a future provider without changing application code.
 
 ## Netlify Identity Status
 
-**Netlify Identity is fully supported.** Although a deprecation was announced in 2025, Netlify reversed that decision in February 2026 after community feedback. Identity remains a first-class Netlify service with ongoing reliability and security updates.
+**Netlify Identity is fully supported in the current implementation.** Although a deprecation was announced in 2025, Netlify reversed that decision in February 2026 after community feedback. Identity remains the current provider until a separately verified migration and cutover.
 
 **Source**: https://www.netlify.com/blog/auth0-extension-identity-changes/
 
-Auth0 is available as an alternative for teams needing enterprise features ([MFA](https://en.wikipedia.org/wiki/Multi-factor_authentication), [SSO](https://en.wikipedia.org/wiki/Single_sign-on)), but migration is **not required**.
+## Migration boundary
+
+Auth0 is the decided target for the Flexpair hub-login migration, not an optional alternative. Auth0 support is **not implemented in this submodule**. This README documents the current Netlify adapter and must not be used as migration authority.
+
+For an explicit migration-execution request, start in the Flexpair umbrella root and read `AGENTS.md`, `AUTH0-MIGRATION-RUNBOOK.md`, `AUTH0-MIGRATION-PLAN.md`, and decisions A-12, A-14, and A-15 in `DECISIONS.md` before changing this submodule. Keep the Netlify adapter, identity proxy, invite path, recovery path, and rollback path available until the umbrella acceptance matrix says otherwise.
 
 ## Architecture
 
@@ -21,7 +25,8 @@ Application code
      |
   AuthProvider interface (common API)
      |
-  NetlifyIdentityAdapter (production)
+  NetlifyIdentityAdapter (current production)
+  Auth0 adapter (planned; not implemented)
 ```
 
 ### Files

--- a/package-lock.json
+++ b/package-lock.json
@@ -2981,9 +2981,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5276,9 +5276,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -5756,9 +5756,9 @@
       }
     },
     "node_modules/multimatch/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5780,9 +5780,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -6229,9 +6229,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6248,7 +6248,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7483,9 +7483,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "overrides": {
     "ws": "8.21.0",
     "magic-string": "0.30.10",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.1",
     "@babel/core": "7.29.7",
     "linkify-it": "5.0.2",
     "markdown-it": "14.3.0"


### PR DESCRIPTION
## Summary
- Clarify that Netlify Identity is the current implementation.
- Mark Auth0 as the decided Flexpair target, not as an optional provider already supported here.
- Route explicit migration work back to the umbrella runbook, plan, and decisions.
- Remove stale Supabase migration guidance from the submodule instructions.

## Verification
- git diff --check
- Local Markdown link check from the umbrella repository
- No runtime or tenant changes

The umbrella repository pointer is prepared in commit e72d5e7 and should be merged only after this PR.