### PR TITLE
chore: remove unused package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "mumbling-mole",
-  "version": "4.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mumbling-mole",
-      "version": "4.0.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "pinia": "4.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "mumbling-mole",
-  "version": "4.0.3",
   "description": "An HTML5 Mumble client.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Remove the unused application `version` from `package.json`.
- Remove the corresponding root metadata entries from `package-lock.json`.
- Keep the Git/Docker release version independent: deployment uses Git tag and image tag `5.1.7`.

## Verification
- Both JSON files parse successfully.
- `npm ci` passed without restoring the fields.
- `npm run build` passed.
- `npm run test:unit -- --runInBand` passed: 61 suites / 1,776 tests.
- `git diff --check` passed.
